### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -147,3 +147,7 @@ For more detailed information on specific aspects of the project, refer to the d
 - And more...
 
 These documents should be consulted when making changes or adding new features to ensure consistency and adherence to project standards.
+
+## Automated Dependency Updates
+
+This repository uses [Dependabot](https://docs.github.com/en/code-security/dependabot) to keep npm packages and GitHub Actions workflows up to date.


### PR DESCRIPTION
## Summary
- configure Dependabot for npm and GitHub Actions
- document automated dependency updates in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6865014ba924832ea61a01acdab14079