### PR TITLE
fix: stabilize MonthlyChart selector for zustand v5

### DIFF
--- a/src/components/dashboard/MonthlyChart.tsx
+++ b/src/components/dashboard/MonthlyChart.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useDonationStore } from "@/lib/store";
+import { useShallow } from "zustand/shallow";
 import { formatCurrency } from "@/lib/utils";
 import { format, parse, subMonths } from "date-fns";
 import { he } from "date-fns/locale";
@@ -53,19 +54,21 @@ export function MonthlyChart() {
     setIsLoadingServerMonthlyChartData,
     setServerMonthlyChartDataError,
     setCanLoadMoreChartData,
-  } = useDonationStore((state) => ({
-    serverMonthlyChartData: state.serverMonthlyChartData,
-    currentChartEndDate: state.currentChartEndDate,
-    isLoadingServerMonthlyChartData: state.isLoadingServerMonthlyChartData,
-    serverMonthlyChartDataError: state.serverMonthlyChartDataError,
-    canLoadMoreChartData: state.canLoadMoreChartData,
-    setServerMonthlyChartData: state.setServerMonthlyChartData,
-    setCurrentChartEndDate: state.setCurrentChartEndDate,
-    setIsLoadingServerMonthlyChartData:
-      state.setIsLoadingServerMonthlyChartData,
-    setServerMonthlyChartDataError: state.setServerMonthlyChartDataError,
-    setCanLoadMoreChartData: state.setCanLoadMoreChartData,
-  }));
+  } = useDonationStore(
+    useShallow((state) => ({
+      serverMonthlyChartData: state.serverMonthlyChartData,
+      currentChartEndDate: state.currentChartEndDate,
+      isLoadingServerMonthlyChartData: state.isLoadingServerMonthlyChartData,
+      serverMonthlyChartDataError: state.serverMonthlyChartDataError,
+      canLoadMoreChartData: state.canLoadMoreChartData,
+      setServerMonthlyChartData: state.setServerMonthlyChartData,
+      setCurrentChartEndDate: state.setCurrentChartEndDate,
+      setIsLoadingServerMonthlyChartData:
+        state.setIsLoadingServerMonthlyChartData,
+      setServerMonthlyChartDataError: state.setServerMonthlyChartDataError,
+      setCanLoadMoreChartData: state.setCanLoadMoreChartData,
+    }))
+  );
 
   const [initialLoadAttempted, setInitialLoadAttempted] = useState(false);
   const [platformReady, setPlatformReady] = useState(false);


### PR DESCRIPTION
## Summary
- use `useShallow` in MonthlyChart to keep selector output stable after Zustand v5 upgrade

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 111 problems, e.g. "CardTitle is defined but never used")*

------
https://chatgpt.com/codex/tasks/task_e_688b331065ec832ea1af3a938d302cfc