### PR TITLE
fix: stabilize Zustand selectors for v5 upgrade

### DIFF
--- a/src/components/TransactionsTable/ExportButton.tsx
+++ b/src/components/TransactionsTable/ExportButton.tsx
@@ -10,16 +10,19 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Download, Loader2 } from "lucide-react"; // Added Loader2
+import { useShallow } from "zustand/react/shallow";
 import { useTableTransactionsStore } from "@/lib/tableTransactions/tableTransactions.store"; // Updated path
 import { usePlatform } from "@/contexts/PlatformContext";
 
 export function ExportButton() {
   const { exportTransactions, exportLoading, exportError } =
-    useTableTransactionsStore((state) => ({
-      exportTransactions: state.exportTransactions,
-      exportLoading: state.exportLoading,
-      exportError: state.exportError,
-    }));
+    useTableTransactionsStore(
+      useShallow((state) => ({
+        exportTransactions: state.exportTransactions,
+        exportLoading: state.exportLoading,
+        exportError: state.exportError,
+      }))
+    );
   const { platform } = usePlatform();
   const [prevExportLoading, setPrevExportLoading] = useState(false);
 

--- a/src/components/TransactionsTable/TransactionsFilters.tsx
+++ b/src/components/TransactionsTable/TransactionsFilters.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useTableTransactionsStore } from "@/lib/tableTransactions/tableTransactions.store";
 import {
   initialTableTransactionFilters,
@@ -64,15 +65,18 @@ const recurringFrequencyOptions = {
 
 export function TransactionsFilters() {
   const { platform } = usePlatform();
-  const storeFilters = useTableTransactionsStore((state) => state.filters);
-  const setStoreFilters = useTableTransactionsStore(
-    (state) => state.setFilters
-  );
-  const resetStoreFiltersState = useTableTransactionsStore(
-    (state) => state.resetFiltersState
-  );
-  const fetchTransactions = useTableTransactionsStore(
-    (state) => state.fetchTransactions
+  const {
+    storeFilters,
+    setStoreFilters,
+    resetStoreFiltersState,
+    fetchTransactions,
+  } = useTableTransactionsStore(
+    useShallow((state) => ({
+      storeFilters: state.filters,
+      setStoreFilters: state.setFilters,
+      resetStoreFiltersState: state.resetFiltersState,
+      fetchTransactions: state.fetchTransactions,
+    }))
   );
 
   const [localSearch, setLocalSearch] = useState(storeFilters.search);

--- a/src/components/TransactionsTable/TransactionsTableDisplay.tsx
+++ b/src/components/TransactionsTable/TransactionsTableDisplay.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useTableTransactionsStore } from "@/lib/tableTransactions/tableTransactions.store";
 import { usePlatform } from "@/contexts/PlatformContext";
 import { Table, TableBody, TableRow, TableCell } from "@/components/ui/table";
@@ -56,7 +57,19 @@ export function TransactionsTableDisplay() {
     sorting,
     setSorting,
     deleteTransaction,
-  } = useTableTransactionsStore();
+  } = useTableTransactionsStore(
+    useShallow((state) => ({
+      transactions: state.transactions,
+      loading: state.loading,
+      error: state.error,
+      fetchTransactions: state.fetchTransactions,
+      setLoadMorePagination: state.setLoadMorePagination,
+      pagination: state.pagination,
+      sorting: state.sorting,
+      setSorting: state.setSorting,
+      deleteTransaction: state.deleteTransaction,
+    }))
+  );
 
   const { platform } = usePlatform(); // platform is used directly here for API calls
   const navigate = useNavigate();

--- a/src/components/dashboard/MonthlyChart.tsx
+++ b/src/components/dashboard/MonthlyChart.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useDonationStore } from "@/lib/store";
+import { useShallow } from "zustand/shallow";
 import { formatCurrency } from "@/lib/utils";
 import { format, parse, subMonths } from "date-fns";
 import { he } from "date-fns/locale";
@@ -53,19 +54,21 @@ export function MonthlyChart() {
     setIsLoadingServerMonthlyChartData,
     setServerMonthlyChartDataError,
     setCanLoadMoreChartData,
-  } = useDonationStore((state) => ({
-    serverMonthlyChartData: state.serverMonthlyChartData,
-    currentChartEndDate: state.currentChartEndDate,
-    isLoadingServerMonthlyChartData: state.isLoadingServerMonthlyChartData,
-    serverMonthlyChartDataError: state.serverMonthlyChartDataError,
-    canLoadMoreChartData: state.canLoadMoreChartData,
-    setServerMonthlyChartData: state.setServerMonthlyChartData,
-    setCurrentChartEndDate: state.setCurrentChartEndDate,
-    setIsLoadingServerMonthlyChartData:
-      state.setIsLoadingServerMonthlyChartData,
-    setServerMonthlyChartDataError: state.setServerMonthlyChartDataError,
-    setCanLoadMoreChartData: state.setCanLoadMoreChartData,
-  }));
+  } = useDonationStore(
+    useShallow((state) => ({
+      serverMonthlyChartData: state.serverMonthlyChartData,
+      currentChartEndDate: state.currentChartEndDate,
+      isLoadingServerMonthlyChartData: state.isLoadingServerMonthlyChartData,
+      serverMonthlyChartDataError: state.serverMonthlyChartDataError,
+      canLoadMoreChartData: state.canLoadMoreChartData,
+      setServerMonthlyChartData: state.setServerMonthlyChartData,
+      setCurrentChartEndDate: state.setCurrentChartEndDate,
+      setIsLoadingServerMonthlyChartData:
+        state.setIsLoadingServerMonthlyChartData,
+      setServerMonthlyChartDataError: state.setServerMonthlyChartDataError,
+      setCanLoadMoreChartData: state.setCanLoadMoreChartData,
+    }))
+  );
 
   const [initialLoadAttempted, setInitialLoadAttempted] = useState(false);
   const [platformReady, setPlatformReady] = useState(false);

--- a/src/components/dashboard/MonthlyChart.tsx
+++ b/src/components/dashboard/MonthlyChart.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useDonationStore } from "@/lib/store";
-import { useShallow } from "zustand/shallow";
+import { useShallow } from "zustand/react/shallow";
 import { formatCurrency } from "@/lib/utils";
 import { format, parse, subMonths } from "date-fns";
 import { he } from "date-fns/locale";

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -25,6 +25,7 @@ import { Input } from '@/components/ui/input';
 import { FileSpreadsheet, FileText, FileJson } from 'lucide-react';
 import { exportToExcel, exportToPDF } from '@/lib/utils';
 import { useDonationStore } from '@/lib/store';
+import { useShallow } from 'zustand/react/shallow';
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -40,7 +41,13 @@ export function DataTable<TData, TValue>({
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = React.useState('');
-  const { settings, incomes, donations } = useDonationStore();
+  const { settings, incomes, donations } = useDonationStore(
+    useShallow((state: any) => ({
+      settings: state.settings,
+      incomes: state.incomes,
+      donations: state.donations,
+    }))
+  );
 
   const table = useReactTable({
     data,

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -42,7 +42,7 @@ export function DataTable<TData, TValue>({
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = React.useState('');
   const { settings, incomes, donations } = useDonationStore(
-    useShallow((state: any) => ({
+    useShallow((state: DonationStoreState) => ({
       settings: state.settings,
       incomes: state.incomes,
       donations: state.donations,

--- a/src/components/ui/date-range-picker.tsx
+++ b/src/components/ui/date-range-picker.tsx
@@ -27,7 +27,7 @@ export function DatePickerWithRange({
   date,
   onDateChange,
 }: DatePickerWithRangeProps) {
-  const { settings } = useDonationStore();
+  const settings = useDonationStore((state) => state.settings);
 
   const formatDate = (date: Date) => {
     if (settings.calendarType === "hebrew") {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/card";
 import { useTheme } from "@/lib/theme";
 import { useDonationStore } from "@/lib/store";
+import { useShallow } from "zustand/react/shallow";
 import { clearAllData } from "@/lib/data-layer";
 import toast from "react-hot-toast";
 import { usePlatform } from "@/contexts/PlatformContext";
@@ -23,12 +24,15 @@ import { NotificationSettingsCard } from "@/components/settings/NotificationSett
 import { CalendarSettingsCard } from "@/components/settings/CalendarSettingsCard";
 import { ClearDataSection } from "@/components/settings/ClearDataSection";
 import { ImportExportDataSection } from "@/components/settings/ImportExportDataSection";
-import { Button } from "@/components/ui/button";
-import { getPlatform } from "@/lib/platformManager";
 
 export function SettingsPage() {
   const { theme, setTheme } = useTheme();
-  const { settings, updateSettings } = useDonationStore();
+  const { settings, updateSettings } = useDonationStore(
+    useShallow((state) => ({
+      settings: state.settings,
+      updateSettings: state.updateSettings,
+    }))
+  );
   const [isClearing, setIsClearing] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [isImporting, setIsImporting] = useState(false);


### PR DESCRIPTION
## Summary
- ensure `useTableTransactionsStore` selector is stable to prevent infinite renders in the transactions table
- use shallow selectors across settings and shared UI to keep Zustand references stable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 110 problems, e.g. "'StagewiseToolbar' is defined but never used")*

------
https://chatgpt.com/codex/tasks/task_e_688b331065ec832ea1af3a938d302cfc