### PR TITLE
chore: configure updater with public key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,16 @@
   "productName": "Ten10",
   "version": "0.2.9",
   "identifier": "com.ten10.dev",
-  "plugins": {},
+  "plugins": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/yossi-weinberger/ten10/releases/latest/download/latest.json"
+      ],
+      "dialog": true,
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEU2MkFDRUQyMDg5N0IzRDMKUldUVHM1Y0kwczRxNXNFWGpCajM4d3c2blpkUE9jbXRNOURJeTNvcnRFMzZ6bmFOUTVVRWVaKzUK"
+    }
+  },
   "app": {
     "windows": [],
     "security": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables the Tauri updater in `src-tauri/tauri.conf.json` with GitHub release endpoint, update dialog, and public key.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94d839887b42d83ea4ebbc01026f292173d90104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->