### PR TITLE
fix: enable native-tls in updater to solve network filtering issues

### DIFF
--- a/llm-instructions/platforms/desktop-release-system-guide.md
+++ b/llm-instructions/platforms/desktop-release-system-guide.md
@@ -355,7 +355,7 @@ Example:
 
 ```toml
 # Cargo.toml
-tauri-plugin-updater = "2.9.0"
+tauri-plugin-updater = { version = "2.9.0", default-features = false, features = ["native-tls", "zip"] }
 ```
 
 ```json

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ tauri-plugin-dialog = "2.4.0"
 tauri-plugin-os = "2.3.1"
 tauri-plugin-notification = "2.3.1"
 tauri-plugin-autostart = "2.5.0"
-tauri-plugin-updater = "2.9.0"
+tauri-plugin-updater = { version = "2.9.0", default-features = false, features = ["native-tls", "zip"] }
 tauri-plugin-clipboard-manager = "2.1.0" 
 
 [features]


### PR DESCRIPTION
This change switches tauri-plugin-updater to use `native-tls` instead of the default rustls. This resolves SSL handshake failures on networks with content filtering (e.g., NetFree, Rimon) that perform SSL inspection, by leveraging the OS trust store (Schannel on Windows).

Closes #160