### PR TITLE
Update update-public-stats.yml

### DIFF
--- a/.github/workflows/update-public-stats.yml
+++ b/.github/workflows/update-public-stats.yml
@@ -4,6 +4,9 @@
 name: Update public stats
 
 on:
+  push:
+    branches: [main]
+    paths: [".github/workflows/update-public-stats.yml", "scripts/update-public-stats.js"]
   schedule:
     - cron: "0 12 * * 0" # weekly, Sunday 12:00 UTC
   workflow_dispatch:
@@ -33,7 +36,17 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: node scripts/update-public-stats.js
 
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet .github/public-stats.json; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adds a new trigger and prevents opening no-op PRs; main impact is CI behavior and PR noise reduction.
> 
> **Overview**
> The `Update public stats` GitHub Actions workflow now also runs on pushes to `main` that touch the workflow or `scripts/update-public-stats.js`, in addition to the weekly schedule/manual run.
> 
> It adds a `git diff` check so the `peter-evans/create-pull-request` step only runs when `.github/public-stats.json` actually changed, avoiding no-op PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a484f01f1a4c82076181ffe36059d400cd603a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->