### PR TITLE
Fix/recurring cron auth

### DIFF
--- a/llm-instructions/backend/supabase-database-migrations-workflow.md
+++ b/llm-instructions/backend/supabase-database-migrations-workflow.md
@@ -104,17 +104,30 @@ Merge. Production already has the migration from step 4. Push to main triggers t
 
 ## Migrations Requiring Vault Secrets
 
-Some migrations (e.g. cron with dynamic URL) use `vault.decrypted_secrets`. Set the secret **per environment** before or right after applying:
+Some migrations (e.g. cron jobs) use `vault.decrypted_secrets`. Secrets must be set **per environment** manually via the Supabase Dashboard (never in git).
 
+### Required Vault Secrets
+
+| Name | Production | Staging |
+|------|-----------|---------|
+| `functions_base_url` | `https://flpzqbvbymoluoeeeofg.supabase.co` | `https://ngtsnskyupageagcmqdp.supabase.co` |
+| `service_role_key` | service_role JWT from Project Settings → API | service_role JWT from Project Settings → API |
+
+### How to Add
+
+**Dashboard (recommended – secret never touches git):**
+Dashboard → Project Settings → Vault → New Secret
+
+**Or via SQL (only if value is not sensitive to log):**
 ```sql
--- Production
-SELECT vault.create_secret('https://flpzqbvbymoluoeeeofg.supabase.co', 'functions_base_url', 'Base URL for cron');
-
--- Staging
-SELECT vault.create_secret('https://ngtsnskyupageagcmqdp.supabase.co', 'functions_base_url', 'Base URL for cron');
+SELECT vault.create_secret('<value>', '<name>', '<description>');
 ```
 
-See `supabase/MIGRATION_VAULT_SETUP.md` for details.
+### Which cron jobs use vault secrets
+
+| Cron job | Vault secrets used |
+|----------|--------------------|
+| `daily-recurring-executor` | `functions_base_url`, `service_role_key` |
 
 ---
 
@@ -132,4 +145,4 @@ Production gets functions via GitHub Action (`deploy-supabase-functions.yml`) on
 
 ## References
 
-- `supabase/MIGRATION_VAULT_SETUP.md` – Vault secrets for cron migrations
+- `supabase/MIGRATION_VAULT_SETUP.md` – Full list of required Vault secrets per environment

--- a/supabase/MIGRATION_VAULT_SETUP.md
+++ b/supabase/MIGRATION_VAULT_SETUP.md
@@ -1,0 +1,48 @@
+# Supabase Vault Setup
+
+This file documents the secrets that must exist in the Supabase Vault for cron jobs and migrations to work correctly.
+
+Secrets are managed via the **Supabase Dashboard → Project Settings → Vault** and are **never stored in git**.
+
+---
+
+## Required Secrets
+
+### `functions_base_url`
+
+Base URL for calling Edge Functions from cron jobs.
+
+| Environment | Value |
+|-------------|-------|
+| Production  | `https://flpzqbvbymoluoeeeofg.supabase.co` |
+| Staging     | `https://ngtsnskyupageagcmqdp.supabase.co` |
+
+### `service_role_key`
+
+The `service_role` JWT used to authenticate cron job requests to Edge Functions.
+
+| Environment | Value |
+|-------------|-------|
+| Production  | service_role JWT from Dashboard → Project Settings → API |
+| Staging     | service_role JWT from Dashboard → Project Settings → API |
+
+> **Security note:** This key bypasses Row Level Security. Never commit it to git.
+> Always add it via the Dashboard UI.
+
+---
+
+## Cron Jobs That Use Vault
+
+| Job name | Secrets used |
+|----------|-------------|
+| `daily-recurring-executor` | `functions_base_url`, `service_role_key` |
+
+---
+
+## How to Verify Secrets Are Set
+
+```sql
+SELECT name FROM vault.decrypted_secrets ORDER BY name;
+```
+
+Expected output: `functions_base_url`, `service_role_key`

--- a/supabase/migrations/20260306120000_fix_daily_recurring_executor_auth.sql
+++ b/supabase/migrations/20260306120000_fix_daily_recurring_executor_auth.sql
@@ -1,0 +1,5 @@
+-- Fix: Add Authorization header to daily-recurring-executor cron job.
+-- The edge function requires a Bearer token (added in the auth-hardening commit),
+-- but the cron job was never updated to include one, causing 401 errors.
+-- NOTE: Superseded by 20260306130000 which moves the token to Supabase Vault.
+-- Applied directly via MCP to production (token not stored in git).

--- a/supabase/migrations/20260306130000_fix_recurring_executor_use_vault_token.sql
+++ b/supabase/migrations/20260306130000_fix_recurring_executor_use_vault_token.sql
@@ -1,0 +1,24 @@
+-- Remove hardcoded service_role JWT from cron job command.
+-- Replace with vault reference, matching the pattern used for functions_base_url.
+--
+-- PREREQUISITE: Add 'service_role_key' to Supabase Vault before applying.
+--   Dashboard → Project Settings → Vault → New Secret
+--   Name: service_role_key
+--   Value: <your service_role JWT>
+
+SELECT cron.unschedule('daily-recurring-executor');
+
+SELECT cron.schedule(
+  'daily-recurring-executor',
+  '0 0 * * *',
+  $$
+    SELECT net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/process-recurring-transactions',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      ),
+      body := '{}'::jsonb
+    );
+  $$
+);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates a production cron job to use Vault-provided `service_role_key` for Edge Function auth; misconfigured/missing secrets could cause scheduled processing to fail. No schema changes, but it affects recurring transaction execution reliability.
> 
> **Overview**
> Fixes the `daily-recurring-executor` cron job to authenticate its Edge Function call by adding an `Authorization: Bearer ...` header sourced from Supabase Vault, and removes any need for hardcoded tokens in SQL.
> 
> Adds/updates migration and workflow docs to explicitly list required Vault secrets per environment (`functions_base_url`, `service_role_key`) and how to configure/verify them via the Supabase Dashboard (never in git).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99b028df027338e964c54a9664490b8ab27a110a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->