### PR TITLE
chore: update Node.js and GitHub Actions versions in workflows

### DIFF
--- a/.github/workflows/deploy-supabase-functions.yml
+++ b/.github/workflows/deploy-supabase-functions.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20.17.0"
+          node-version: "24"
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1

--- a/.github/workflows/deploy-supabase-migrations.yml
+++ b/.github/workflows/deploy-supabase-migrations.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install Rust stable

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/tauri-build-check.yml
+++ b/.github/workflows/tauri-build-check.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Updated the Node.js version to 24 and upgraded the GitHub Actions checkout and setup-node actions to version 6 across multiple workflow files. This change ensures compatibility with the latest features and improvements in the respective tools.