### PR TITLE
test: phase-0 safety net — vitest + Rust characterization tests

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Ten10"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "env_logger",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ tauri-plugin-updater = { version = "2.10", default-features = false, features = 
 tauri-plugin-clipboard-manager = "2.1.0"
 tauri-plugin-stronghold = "2.3.1"
 
+[dev-dependencies]
+# "test" feature enables tauri::test::mock_app for command-handler tests only
+tauri = { version = "2.10", features = ["test"] }
+
 [features]
 custom-protocol = ["tauri/custom-protocol"]
 

--- a/src-tauri/src/commands/transaction_commands.rs
+++ b/src-tauri/src/commands/transaction_commands.rs
@@ -819,3 +819,251 @@ pub fn get_distinct_payment_methods(
 
     Ok(methods)
 }
+
+// ---------------------------------------------------------------------------
+// Characterization tests for get_filtered_transactions_handler.
+// They pin the CURRENT filter/sort/pagination behavior against an in-memory
+// SQLite DB, as a safety net before any refactor of the WHERE-clause building.
+// Test-only code: compiled exclusively under `cargo test`.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use serde_json::json;
+    use std::sync::Mutex;
+    use tauri::Manager;
+
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "CREATE TABLE transactions (
+                id TEXT PRIMARY KEY, user_id TEXT, date TEXT NOT NULL, amount REAL NOT NULL,
+                currency TEXT NOT NULL, description TEXT, type TEXT NOT NULL, category TEXT,
+                is_chomesh INTEGER, recipient TEXT, payment_method TEXT, created_at TEXT,
+                updated_at TEXT, source_recurring_id TEXT, occurrence_number INTEGER,
+                original_amount REAL, original_currency TEXT, conversion_rate REAL,
+                conversion_date TEXT, rate_source TEXT
+            );
+            CREATE TABLE recurring_transactions (
+                id TEXT PRIMARY KEY, user_id TEXT, status TEXT NOT NULL DEFAULT 'active',
+                start_date TEXT NOT NULL, next_due_date TEXT NOT NULL,
+                frequency TEXT NOT NULL DEFAULT 'monthly', day_of_month INTEGER NOT NULL,
+                total_occurrences INTEGER, execution_count INTEGER NOT NULL DEFAULT 0,
+                description TEXT, amount REAL NOT NULL, currency TEXT NOT NULL,
+                type TEXT NOT NULL, category TEXT, is_chomesh INTEGER, recipient TEXT,
+                payment_method TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+                original_amount REAL, original_currency TEXT, conversion_rate REAL,
+                conversion_date TEXT, rate_source TEXT
+            );",
+        )
+        .expect("schema");
+
+        conn.execute_batch(
+            "INSERT INTO recurring_transactions
+                (id, status, start_date, next_due_date, frequency, day_of_month,
+                 execution_count, amount, currency, type, created_at, updated_at)
+             VALUES ('rec1', 'active', '2024-01-01', '2024-04-01', 'monthly', 1,
+                 3, 30.0, 'ILS', 'donation', '2024-01-01', '2024-01-01');
+
+             INSERT INTO transactions
+                (id, date, amount, currency, description, type, category, is_chomesh,
+                 payment_method, created_at)
+             VALUES ('t1', '2024-01-10', 100.0, 'ILS', 'משכורת ינואר', 'income', 'salary', 1,
+                 'cash', '2024-01-10T10:00:00Z');
+
+             INSERT INTO transactions
+                (id, date, amount, currency, description, type, category,
+                 payment_method, created_at)
+             VALUES ('t2', '2024-02-15', 50.0, 'ILS', 'מכולת שכונתית', 'expense', 'food',
+                 'credit', '2024-02-15T10:00:00Z');
+
+             INSERT INTO transactions
+                (id, date, amount, currency, description, type, recipient,
+                 payment_method, created_at, source_recurring_id)
+             VALUES ('t3', '2024-03-01', 30.0, 'ILS', 'תרומה חודשית', 'donation', 'ישיבה',
+                 'cash', '2024-03-01T10:00:00Z', 'rec1');",
+        )
+        .expect("seed");
+        conn
+    }
+
+    fn mock_app() -> tauri::App<tauri::test::MockRuntime> {
+        let app = tauri::test::mock_app();
+        app.manage(crate::DbState(Mutex::new(test_db())));
+        app
+    }
+
+    fn args(filters: serde_json::Value, sorting: serde_json::Value) -> GetFilteredTransactionsArgs {
+        serde_json::from_value(json!({
+            "filters": filters,
+            "pagination": { "page": 1, "limit": 50 },
+            "sorting": sorting,
+        }))
+        .expect("valid args")
+    }
+
+    fn run(
+        app: &tauri::App<tauri::test::MockRuntime>,
+        filters: serde_json::Value,
+        sorting: serde_json::Value,
+    ) -> PaginatedTransactionsResponse {
+        get_filtered_transactions_handler(app.state::<crate::DbState>(), args(filters, sorting))
+            .expect("handler ok")
+    }
+
+    fn default_sort() -> serde_json::Value {
+        json!({ "field": "date", "direction": "asc" })
+    }
+
+    fn ids(res: &PaginatedTransactionsResponse) -> Vec<String> {
+        res.transactions.iter().map(|t| t.transaction.id.clone()).collect()
+    }
+
+    #[test]
+    fn no_filters_returns_everything() {
+        let app = mock_app();
+        let res = run(&app, json!({}), default_sort());
+        assert_eq!(res.total_count, 3);
+        assert_eq!(ids(&res), vec!["t1", "t2", "t3"]);
+    }
+
+    #[test]
+    fn search_matches_description_and_recipient() {
+        let app = mock_app();
+        let by_desc = run(&app, json!({ "search": "מכולת" }), default_sort());
+        assert_eq!(ids(&by_desc), vec!["t2"]);
+
+        let by_recipient = run(&app, json!({ "search": "ישיבה" }), default_sort());
+        assert_eq!(ids(&by_recipient), vec!["t3"]);
+
+        let no_match = run(&app, json!({ "search": "לא-קיים" }), default_sort());
+        assert_eq!(no_match.total_count, 0);
+    }
+
+    #[test]
+    fn empty_search_is_ignored() {
+        let app = mock_app();
+        let res = run(&app, json!({ "search": "" }), default_sort());
+        assert_eq!(res.total_count, 3);
+    }
+
+    #[test]
+    fn date_range_filters_inclusively() {
+        let app = mock_app();
+        let from_feb = run(&app, json!({ "dateFrom": "2024-02-01" }), default_sort());
+        assert_eq!(ids(&from_feb), vec!["t2", "t3"]);
+
+        let feb_only = run(
+            &app,
+            json!({ "dateFrom": "2024-02-01", "dateTo": "2024-02-29" }),
+            default_sort(),
+        );
+        assert_eq!(ids(&feb_only), vec!["t2"]);
+
+        // boundaries are inclusive
+        let exact = run(
+            &app,
+            json!({ "dateFrom": "2024-01-10", "dateTo": "2024-01-10" }),
+            default_sort(),
+        );
+        assert_eq!(ids(&exact), vec!["t1"]);
+    }
+
+    #[test]
+    fn filters_by_types_and_payment_methods() {
+        let app = mock_app();
+        let types = run(&app, json!({ "types": ["income", "donation"] }), default_sort());
+        assert_eq!(ids(&types), vec!["t1", "t3"]);
+
+        let cash = run(&app, json!({ "paymentMethods": ["cash"] }), default_sort());
+        assert_eq!(ids(&cash), vec!["t1", "t3"]);
+
+        let combined = run(
+            &app,
+            json!({ "types": ["donation"], "paymentMethods": ["cash"] }),
+            default_sort(),
+        );
+        assert_eq!(ids(&combined), vec!["t3"]);
+    }
+
+    #[test]
+    fn show_only_recurring_vs_regular() {
+        let app = mock_app();
+        let recurring = run(&app, json!({ "showOnly": "recurring" }), default_sort());
+        assert_eq!(ids(&recurring), vec!["t3"]);
+        let info = recurring.transactions[0]
+            .recurring_info
+            .as_ref()
+            .expect("joined recurring info");
+        assert_eq!(info.frequency, "monthly");
+        assert_eq!(info.status, "active");
+
+        let regular = run(&app, json!({ "showOnly": "regular" }), default_sort());
+        assert_eq!(ids(&regular), vec!["t1", "t2"]);
+
+        let all = run(&app, json!({ "showOnly": "all" }), default_sort());
+        assert_eq!(all.total_count, 3);
+    }
+
+    #[test]
+    fn filters_by_recurring_status_and_frequency() {
+        let app = mock_app();
+        let active = run(&app, json!({ "recurringStatuses": ["active"] }), default_sort());
+        assert_eq!(ids(&active), vec!["t3"]);
+
+        let monthly = run(&app, json!({ "recurringFrequencies": ["monthly"] }), default_sort());
+        assert_eq!(ids(&monthly), vec!["t3"]);
+
+        let paused = run(&app, json!({ "recurringStatuses": ["paused"] }), default_sort());
+        assert_eq!(paused.total_count, 0);
+    }
+
+    #[test]
+    fn sorts_by_amount_both_directions() {
+        let app = mock_app();
+        let asc = run(&app, json!({}), json!({ "field": "amount", "direction": "asc" }));
+        assert_eq!(ids(&asc), vec!["t3", "t2", "t1"]);
+
+        let desc = run(&app, json!({}), json!({ "field": "amount", "direction": "desc" }));
+        assert_eq!(ids(&desc), vec!["t1", "t2", "t3"]);
+    }
+
+    #[test]
+    fn unknown_sort_field_falls_back_to_created_at() {
+        let app = mock_app();
+        let res = run(&app, json!({}), json!({ "field": "bogus", "direction": "asc" }));
+        assert_eq!(res.total_count, 3);
+        assert_eq!(ids(&res), vec!["t1", "t2", "t3"]); // created_at order
+    }
+
+    #[test]
+    fn paginates_with_correct_total_count() {
+        let app = mock_app();
+        let page1: PaginatedTransactionsResponse = get_filtered_transactions_handler(
+            app.state::<crate::DbState>(),
+            serde_json::from_value(json!({
+                "filters": {},
+                "pagination": { "page": 1, "limit": 2 },
+                "sorting": { "field": "date", "direction": "asc" },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(page1.total_count, 3);
+        assert_eq!(ids(&page1), vec!["t1", "t2"]);
+
+        let page2: PaginatedTransactionsResponse = get_filtered_transactions_handler(
+            app.state::<crate::DbState>(),
+            serde_json::from_value(json!({
+                "filters": {},
+                "pagination": { "page": 2, "limit": 2 },
+                "sorting": { "field": "date", "direction": "asc" },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(page2.total_count, 3);
+        assert_eq!(ids(&page2), vec!["t3"]);
+    }
+}

--- a/src/lib/import/header-normalizer.test.ts
+++ b/src/lib/import/header-normalizer.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { cleanHeaderName, normalizeHeaderName } from "./header-normalizer";
+
+describe("cleanHeaderName", () => {
+  it("strips BOM and trims whitespace", () => {
+    expect(cleanHeaderName("﻿ תאריך ")).toBe("תאריך");
+  });
+
+  it("removes invisible bidi control characters", () => {
+    expect(cleanHeaderName("‏סכום‎")).toBe("סכום");
+  });
+
+  it("normalizes Hebrew gershayim and geresh to ASCII quotes", () => {
+    expect(cleanHeaderName("סה״כ")).toBe('סה"כ');
+    expect(cleanHeaderName("צ׳ק")).toBe("צ'ק");
+  });
+
+  it("preserves casing", () => {
+    expect(cleanHeaderName("Amount USD")).toBe("Amount USD");
+  });
+});
+
+describe("normalizeHeaderName", () => {
+  it("cleans and lowercases", () => {
+    expect(normalizeHeaderName(" Date ")).toBe("date");
+    expect(normalizeHeaderName("﻿AMOUNT")).toBe("amount");
+  });
+});

--- a/src/lib/import/parsers.test.ts
+++ b/src/lib/import/parsers.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { parseCSVText, parseFile, MAX_FILE_SIZE_BYTES, MAX_ROWS } from "./parsers";
+
+// Characterization tests: they pin the CURRENT behavior of the custom CSV
+// parser (quotes, delimiters, Hebrew, BOM) as a safety net before refactors.
+
+describe("parseCSVText", () => {
+  it("parses a simple comma-separated file with Hebrew headers", () => {
+    const { headers, rows } = parseCSVText(
+      "תאריך,סכום,תיאור\n2024-01-15,100.50,מכולת\n2024-01-16,200,פירות"
+    );
+    expect(headers).toEqual(["תאריך", "סכום", "תיאור"]);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ תאריך: "2024-01-15", סכום: "100.50", תיאור: "מכולת" });
+  });
+
+  it("strips BOM and normalizes CRLF line endings", () => {
+    const { headers, rows } = parseCSVText("﻿a,b\r\n1,2\r\n3,4");
+    expect(headers).toEqual(["a", "b"]);
+    expect(rows).toEqual([
+      { a: "1", b: "2" },
+      { a: "3", b: "4" },
+    ]);
+  });
+
+  it("keeps delimiters inside quoted fields", () => {
+    const { rows } = parseCSVText('a,b\n"מכולת, שכונתית",5');
+    expect(rows[0]).toEqual({ a: "מכולת, שכונתית", b: "5" });
+  });
+
+  it('unescapes doubled quotes ("" -> ")', () => {
+    const { rows } = parseCSVText('a,b\n"He said ""hi""",2');
+    expect(rows[0].a).toBe('He said "hi"');
+  });
+
+  it("preserves newlines inside quoted fields", () => {
+    const { rows } = parseCSVText('a,b\n"line1\nline2",3');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].a).toBe("line1\nline2");
+  });
+
+  it("detects semicolon delimiter", () => {
+    const { headers, rows } = parseCSVText("a;b;c\n1;2;3");
+    expect(headers).toEqual(["a", "b", "c"]);
+    expect(rows[0]).toEqual({ a: "1", b: "2", c: "3" });
+  });
+
+  it("detects tab delimiter", () => {
+    const { headers, rows } = parseCSVText("a\tb\n1\t2");
+    expect(headers).toEqual(["a", "b"]);
+    expect(rows[0]).toEqual({ a: "1", b: "2" });
+  });
+
+  it("skips leading blank lines before the header row", () => {
+    const { headers, rows } = parseCSVText("\n\na,b\n1,2");
+    expect(headers).toEqual(["a", "b"]);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("skips empty data lines", () => {
+    const { rows } = parseCSVText("a,b\n1,2\n\n3,4\n");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("fills missing trailing values with empty string", () => {
+    const { rows } = parseCSVText("a,b,c\n1,2");
+    expect(rows[0]).toEqual({ a: "1", b: "2", c: "" });
+  });
+
+  it("normalizes Hebrew gershayim in headers (סה״כ -> סה\"כ)", () => {
+    const { headers } = parseCSVText("סה״כ,b\n1,2");
+    expect(headers[0]).toBe('סה"כ');
+  });
+
+  it("returns empty result for empty/whitespace input", () => {
+    expect(parseCSVText("")).toEqual({ headers: [], rows: [] });
+    expect(parseCSVText("\n\n  \n")).toEqual({ headers: [], rows: [] });
+  });
+});
+
+describe("parseFile (CSV)", () => {
+  const csvFile = (content: string, name = "test.csv") =>
+    new File([content], name, { type: "text/csv" });
+
+  it("rejects files over the size limit", async () => {
+    const big = new File([new Uint8Array(MAX_FILE_SIZE_BYTES + 1)], "big.csv");
+    const result = await parseFile(big);
+    expect(result).toMatchObject({ ok: false, error: "too_large" });
+  });
+
+  it("rejects .xls files", async () => {
+    const result = await parseFile(csvFile("a,b", "old.xls"));
+    expect(result).toMatchObject({ ok: false, error: "xls_not_supported" });
+  });
+
+  it("rejects unsupported extensions", async () => {
+    const result = await parseFile(csvFile("a,b", "notes.txt"));
+    expect(result).toMatchObject({ ok: false, error: "unsupported_format" });
+  });
+
+  it("parses a valid CSV file", async () => {
+    const result = await parseFile(csvFile("תאריך,סכום\n2024-01-15,100\n2024-01-16,200"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.file.headers).toEqual(["תאריך", "סכום"]);
+      expect(result.file.rowCount).toBe(2);
+      expect(result.file.sampleRows).toHaveLength(2);
+    }
+  });
+
+  it("generates 'Column N' headers when the first row looks like data", async () => {
+    const result = await parseFile(csvFile("2024-01-15,100.50\n2024-01-16,200.00"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.file.headers).toEqual(["Column 1", "Column 2"]);
+      // The original first row becomes a data row
+      expect(result.file.rowCount).toBe(2);
+      expect(result.file.rows[0]).toEqual({ "Column 1": "2024-01-15", "Column 2": "100.50" });
+      expect(result.file.diagnostics).toEqual([{ code: "generated_headers", count: 2 }]);
+    }
+  });
+
+  it("returns no_data when headers exist but no rows follow", async () => {
+    const result = await parseFile(csvFile("תאריך,סכום\n"));
+    expect(result).toMatchObject({ ok: false, error: "no_data" });
+  });
+
+  it("returns too_many_rows above MAX_ROWS", async () => {
+    const lines = ["a,b", ...Array.from({ length: MAX_ROWS + 1 }, (_, i) => `${i},x`)];
+    const result = await parseFile(csvFile(lines.join("\n")));
+    expect(result).toMatchObject({ ok: false, error: "too_many_rows" });
+  });
+});

--- a/src/lib/utils/currency.test.ts
+++ b/src/lib/utils/currency.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { formatCurrency } from "./currency";
+
+// Intl output varies slightly between ICU versions (NBSP, RTL marks),
+// so assertions strip invisible characters and check content, not exact bytes.
+const clean = (s: string) =>
+  s
+    .replace(/[\u200E\u200F\u061C]/g, "") // LRM / RLM / ALM bidi marks
+    .replace(/\u00A0/g, " ") // NBSP -> regular space
+    .trim();
+
+describe("formatCurrency", () => {
+  it("formats whole ILS amounts without decimals", () => {
+    const out = clean(formatCurrency(100, "ILS", "he"));
+    expect(out).toContain("₪"); // ₪
+    expect(out).toContain("100");
+    expect(out).not.toMatch(/100[.,]0/);
+  });
+
+  it("formats decimal amounts with exactly one decimal digit", () => {
+    const out = clean(formatCurrency(100.25, "ILS", "he"));
+    expect(out).toMatch(/100[.,]3/); // rounded half-up to one digit
+  });
+
+  it("keeps one decimal digit even for x.0-adjacent values", () => {
+    const out = clean(formatCurrency(99.9, "ILS", "he"));
+    expect(out).toMatch(/99[.,]9/);
+  });
+
+  it("formats USD in English with $ symbol", () => {
+    const out = clean(formatCurrency(50, "USD", "en"));
+    expect(out).toContain("$");
+    expect(out).toContain("50");
+  });
+
+  it("formats EUR in English", () => {
+    const out = clean(formatCurrency(75.5, "EUR", "en"));
+    expect(out).toContain("€"); // €
+    expect(out).toMatch(/75[.,]5/);
+  });
+
+  it("falls back to he-IL locale for unknown language", () => {
+    const out = clean(formatCurrency(10, "ILS", "fr"));
+    expect(out).toContain("₪");
+    expect(out).toContain("10");
+  });
+
+  it("handles negative amounts", () => {
+    const out = clean(formatCurrency(-42, "ILS", "he"));
+    expect(out).toContain("42");
+    expect(out).toContain("-");
+  });
+
+  it("handles zero as a whole number", () => {
+    const out = clean(formatCurrency(0, "ILS", "he"));
+    expect(out).toContain("0");
+    expect(out).not.toMatch(/0[.,]0/);
+  });
+});

--- a/src/lib/utils/date-range.test.ts
+++ b/src/lib/utils/date-range.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { getPreviousPeriodRange } from "./date-range";
+
+describe("getPreviousPeriodRange", () => {
+  it("returns the immediately preceding period of equal length", () => {
+    const prev = getPreviousPeriodRange("2024-02-01", "2024-02-29");
+    expect(prev.endDate).toBe("2024-01-31");
+    expect(prev.startDate).toBe("2024-01-03"); // same 28-day span
+  });
+
+  it("crosses a year boundary", () => {
+    const prev = getPreviousPeriodRange("2024-01-01", "2024-01-31");
+    expect(prev.endDate).toBe("2023-12-31");
+    expect(prev.startDate).toBe("2023-12-01");
+  });
+
+  it("handles a single-day range", () => {
+    const prev = getPreviousPeriodRange("2024-06-15", "2024-06-15");
+    expect(prev.endDate).toBe("2024-06-14");
+    expect(prev.startDate).toBe("2024-06-14");
+  });
+});

--- a/src/lib/utils/hebrew-date.test.ts
+++ b/src/lib/utils/hebrew-date.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+
+// hebrew-date imports the app i18n instance only for an error message;
+// mock it so tests don't boot the full i18next browser stack.
+vi.mock("../i18n", () => ({
+  default: { t: (key: string) => key },
+}));
+
+import {
+  getHebrewDate,
+  getHebrewMonth,
+  getHebrewYear,
+  formatHebrewDate,
+  formatHebrewDateWithYear,
+  convertToGregorianDate,
+  isJewishHoliday,
+} from "./hebrew-date";
+
+describe("hebrew-date conversions", () => {
+  // Oct 3, 2024 = 1 Tishrei 5785 (Rosh Hashana)
+  const roshHashana5785 = new Date(2024, 9, 3);
+  // Mar 25, 2024 = 15 Adar II 5784 (leap year with Adar I + Adar II)
+  const shushanPurim5784 = new Date(2024, 2, 25);
+
+  it("returns the Hebrew year, crossing at Tishrei", () => {
+    expect(getHebrewYear(roshHashana5785)).toBe(5785);
+    expect(getHebrewYear(new Date(2024, 9, 2))).toBe(5784); // one day earlier
+  });
+
+  it("returns the Hebrew day of month", () => {
+    expect(getHebrewDate(roshHashana5785)).toBe("1");
+    expect(getHebrewDate(shushanPurim5784)).toBe("15");
+  });
+
+  it("handles Adar II in leap years", () => {
+    expect(getHebrewMonth(shushanPurim5784)).toBe("Adar II");
+  });
+
+  it("formats day + month (+ year)", () => {
+    expect(formatHebrewDate(roshHashana5785)).toBe("1 Tishrei");
+    expect(formatHebrewDateWithYear(roshHashana5785)).toBe("1 Tishrei 5785");
+  });
+
+  it("round-trips Hebrew -> Gregorian (15 Nisan 5784 = Pesach, Apr 23 2024)", () => {
+    const greg = convertToGregorianDate(5784, "Nisan", 15);
+    expect(greg.getFullYear()).toBe(2024);
+    expect(greg.getMonth()).toBe(3); // April
+    expect(greg.getDate()).toBe(23);
+  });
+
+  it("throws on an invalid Hebrew month name", () => {
+    expect(() => convertToGregorianDate(5784, "NotAMonth", 1)).toThrow();
+  });
+
+  it("detects holidays", () => {
+    expect(isJewishHoliday(roshHashana5785)).toBe(true);
+    expect(isJewishHoliday(new Date(2024, 10, 5))).toBe(false); // 4 Cheshvan — plain day
+  });
+});

--- a/src/lib/utils/pdf-helpers.test.ts
+++ b/src/lib/utils/pdf-helpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { splitTextSegments } from "./pdf-helpers";
+
+// Pins RTL/number segmentation behavior used by both PDF exports.
+
+describe("splitTextSegments", () => {
+  it("splits Hebrew text with a thousands+decimal amount", () => {
+    expect(splitTextSegments("דיור: 1,234.56 ₪")).toEqual([
+      { text: "דיור: ", isNumber: false },
+      { text: "1,234.56", isNumber: true },
+      { text: " ₪", isNumber: false },
+    ]);
+  });
+
+  it("keeps a date as a single number segment", () => {
+    expect(splitTextSegments("2024-01-15")).toEqual([
+      { text: "2024-01-15", isNumber: true },
+    ]);
+  });
+
+  it("keeps a time as a single number segment", () => {
+    expect(splitTextSegments("נכון ל-12:30")).toEqual([
+      { text: "נכון ל-", isNumber: false },
+      { text: "12:30", isNumber: true },
+    ]);
+  });
+
+  it("handles a single digit", () => {
+    expect(splitTextSegments("5")).toEqual([{ text: "5", isNumber: true }]);
+  });
+
+  it("handles text without numbers", () => {
+    expect(splitTextSegments("שלום עולם")).toEqual([
+      { text: "שלום עולם", isNumber: false },
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(splitTextSegments("")).toEqual([]);
+  });
+
+  it("alternates segments for interleaved text and numbers", () => {
+    expect(splitTextSegments("a1b")).toEqual([
+      { text: "a", isNumber: false },
+      { text: "1", isNumber: true },
+      { text: "b", isNumber: false },
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+  resolve: {
+    alias: { "@": fileURLToPath(new URL("./src", import.meta.url)) },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Phase 0 of the cleanup/stabilization plan — safety net before any refactor

First test infrastructure for the repo (there were no FE tests and only 3 tiny Rust tests).

### Frontend — 49 tests (vitest, new `vitest.config.ts`)
- `src/lib/import/parsers.test.ts` — custom CSV parser: quotes/escaping, multiline quoted fields, delimiter detection (`,` `;` tab), BOM, Hebrew headers (gershayim), headerless-file detection, size/row limits
- `src/lib/import/header-normalizer.test.ts` — BOM/bidi stripping, Hebrew punctuation normalization
- `src/lib/utils/pdf-helpers.test.ts` — RTL text segmentation (`splitTextSegments`) incl. dates, times, thousands+decimal amounts
- `src/lib/utils/currency.test.ts` — `formatCurrency` decimals policy, locales, negative/zero
- `src/lib/utils/hebrew-date.test.ts` — Hebrew calendar conversions: Tishrei year boundary, Adar II in leap years, Hebrew→Gregorian round-trip, holiday detection
- `src/lib/utils/date-range.test.ts` — previous-period range used by KPI deltas

### Rust — 10 tests (`cargo test`, in-memory SQLite + `tauri::test::mock_app`)
Characterization tests for `get_filtered_transactions_handler` (the 227-line filter/sort/pagination query builder slated for a Phase-3 `FilterBuilder` refactor): search across fields, inclusive date ranges, type/payment-method IN filters, recurring filters + joined `recurring_info`, sorting both directions, unknown-sort-field fallback, pagination with `total_count`.

### No production code changes
Only test files, `vitest.config.ts`, a `#[cfg(test)]` module, and a dev-only `tauri = { features = ["test"] }` dev-dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)