### PR TITLE
fix(landing): prevent horizontal overflow in testimonials carousel

### DIFF
--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -286,7 +286,7 @@ const LandingPage: React.FC = () => {
   return (
     <div
       ref={pageRef}
-      className="min-h-screen bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-800"
+      className="min-h-screen overflow-x-hidden bg-gradient-to-b from-blue-50 to-white dark:from-gray-900 dark:to-gray-800"
       dir={i18n.dir()}
     >
       {/* Language Toggle - Fixed Position */}

--- a/src/pages/landing/sections/TestimonialsSection.tsx
+++ b/src/pages/landing/sections/TestimonialsSection.tsx
@@ -11,6 +11,8 @@ import { Quote, ArrowLeft, ArrowRight } from "lucide-react";
 import { testimonials } from "../constants/testimonials";
 import { cn } from "@/lib/utils";
 
+const INITIAL_TESTIMONIAL_INDEX = Math.floor(testimonials.length / 2);
+
 interface TestimonialsSectionProps {
   sectionRef: React.RefObject<HTMLElement | null>;
 }
@@ -24,7 +26,7 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
   const NextIcon = isRtl ? ArrowLeft : ArrowRight;
 
   const [api, setApi] = useState<CarouselApi | null>(null);
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(INITIAL_TESTIMONIAL_INDEX);
   const [count, setCount] = useState(0);
 
   useEffect(() => {
@@ -45,7 +47,9 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
   }, [api]);
 
   useEffect(() => {
-    api?.reInit();
+    if (!api) return;
+    api.reInit();
+    api.scrollTo(INITIAL_TESTIMONIAL_INDEX, true);
   }, [api, isRtl]);
 
   const scrollTo = useCallback(
@@ -87,6 +91,7 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
             opts={{
               align: "center",
               loop: true,
+              startIndex: INITIAL_TESTIMONIAL_INDEX,
               direction: isRtl ? "rtl" : "ltr",
             }}
             setApi={setApi}

--- a/src/pages/landing/sections/TestimonialsSection.tsx
+++ b/src/pages/landing/sections/TestimonialsSection.tsx
@@ -55,7 +55,7 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
     <section
       id="testimonials"
       ref={sectionRef}
-      className="overflow-x-hidden py-20 px-4 bg-white dark:bg-gray-800"
+      className="py-20 px-4 bg-white dark:bg-gray-800"
     >
       <div className="container relative mx-auto max-w-7xl">
         {/* Section heading */}
@@ -70,98 +70,100 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
             {t("testimonials.title")}
           </motion.h2>
         </div>
+      </div>
 
-        {/* Carousel */}
-        <motion.div
-          initial={{ opacity: 0, y: 32 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true, margin: "0px 0px -80px 0px" }}
-          transition={{ type: "spring", damping: 22, stiffness: 280, delay: 0.15 }}
+      {/* Full-width carousel so side cards can peek without hard clipping */}
+      <motion.div
+        initial={{ opacity: 0, y: 32 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "0px 0px -80px 0px" }}
+        transition={{ type: "spring", damping: 22, stiffness: 280, delay: 0.15 }}
+      >
+        <Carousel
+          className="w-full [&>div:first-child]:overflow-visible"
+          opts={{
+            align: "center",
+            loop: true,
+            // Keep Embla mechanics LTR, mirroring ScreenshotCarousel.
+            direction: "ltr",
+          }}
+          setApi={setApi}
         >
-          <Carousel
-            className="w-full"
-            opts={{
-              align: "center",
-              loop: true,
-              // Keep Embla mechanics LTR, mirroring ScreenshotCarousel.
-              direction: "ltr",
-            }}
-            setApi={setApi}
+          {/* py-8 gives vertical breathing room for the active card's shadow. */}
+          <CarouselContent
+            className="-ml-4 py-8"
+            style={{ direction: "ltr" }}
           >
-            {/* py-8 gives vertical breathing room for the active card's shadow. */}
-            <CarouselContent
-              className="-ml-4 py-8"
-              style={{ direction: "ltr" }}
-            >
-              {testimonials.map((testimonial, index) => {
-                const isActive = index === selectedIndex;
-                return (
-                  // Fixed height prevents section height from jumping between cards.
-                  <CarouselItem
-                    key={index}
-                    className="pl-4 basis-[85%] sm:basis-[60%] lg:basis-[38%] h-64 sm:h-60"
+            {testimonials.map((testimonial, index) => {
+              const isActive = index === selectedIndex;
+              return (
+                // Fixed height prevents section height from jumping between cards.
+                <CarouselItem
+                  key={index}
+                  className="pl-4 basis-[85%] sm:basis-[60%] lg:basis-[38%] h-64 sm:h-60"
+                >
+                  <div
+                    dir={i18n.dir()}
+                    className={cn(
+                      "flex flex-col h-full rounded-2xl border p-7",
+                      // Only transition compositor-friendly properties, not layout.
+                      "motion-safe:transition-[transform,opacity,box-shadow,border-color]",
+                      "motion-safe:duration-500 motion-safe:ease-out",
+                      "will-change-transform",
+                      isActive
+                        ? "bg-white dark:bg-gray-900 border-emerald-200 dark:border-emerald-800 shadow-[0_8px_40px_-8px_rgba(16,185,129,0.22)] dark:shadow-[0_8px_40px_-8px_rgba(16,185,129,0.18)] scale-[1.03] opacity-100"
+                        : "bg-gray-50 dark:bg-gray-900/50 border-gray-200 dark:border-gray-800 shadow-sm scale-[0.92] opacity-65"
+                    )}
                   >
-                    <div
-                      dir={i18n.dir()}
+                    {/* Quote icon */}
+                    <Quote
                       className={cn(
-                        "flex flex-col h-full rounded-2xl border p-7",
-                        // Only transition compositor-friendly properties, not layout.
-                        "motion-safe:transition-[transform,opacity,box-shadow,border-color]",
-                        "motion-safe:duration-500 motion-safe:ease-out",
-                        "will-change-transform",
+                        "w-6 h-6 mb-3 shrink-0",
+                        "motion-safe:transition-colors motion-safe:duration-300",
                         isActive
-                          ? "bg-white dark:bg-gray-900 border-emerald-200 dark:border-emerald-800 shadow-[0_8px_40px_-8px_rgba(16,185,129,0.22)] dark:shadow-[0_8px_40px_-8px_rgba(16,185,129,0.18)] scale-[1.03] opacity-100"
-                          : "bg-gray-50 dark:bg-gray-900/50 border-gray-200 dark:border-gray-800 shadow-sm scale-[0.92] opacity-65"
+                          ? "text-emerald-500 dark:text-emerald-400"
+                          : "text-gray-300 dark:text-gray-700"
                       )}
-                    >
-                      {/* Quote icon */}
-                      <Quote
+                      aria-hidden="true"
+                    />
+
+                    <div className="flex flex-1 items-center justify-center overflow-hidden">
+                      <p
                         className={cn(
-                          "w-6 h-6 mb-3 shrink-0",
+                          "leading-relaxed text-center",
+                          "motion-safe:transition-[color,opacity] motion-safe:duration-300",
+                          isActive
+                            ? "text-gray-800 dark:text-gray-100 text-base md:text-lg opacity-100"
+                            : "text-gray-500 dark:text-gray-400 text-sm md:text-base opacity-80"
+                        )}
+                      >
+                        {t(testimonial.textKey)}
+                      </p>
+                    </div>
+
+                    {/* Name uses text-end: left in Hebrew, right in English, like a signature. */}
+                    <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
+                      <p
+                        className={cn(
+                          "text-end text-sm font-semibold",
                           "motion-safe:transition-colors motion-safe:duration-300",
                           isActive
-                            ? "text-emerald-500 dark:text-emerald-400"
-                            : "text-gray-300 dark:text-gray-700"
+                            ? "text-gray-900 dark:text-white"
+                            : "text-gray-400 dark:text-gray-600"
                         )}
-                        aria-hidden="true"
-                      />
-
-                      <div className="flex flex-1 items-center justify-center overflow-hidden">
-                        <p
-                          className={cn(
-                            "leading-relaxed text-center",
-                            "motion-safe:transition-[color,opacity] motion-safe:duration-300",
-                            isActive
-                              ? "text-gray-800 dark:text-gray-100 text-base md:text-lg opacity-100"
-                              : "text-gray-500 dark:text-gray-400 text-sm md:text-base opacity-80"
-                          )}
-                        >
-                          {t(testimonial.textKey)}
-                        </p>
-                      </div>
-
-                      {/* Name uses text-end: left in Hebrew, right in English, like a signature. */}
-                      <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
-                        <p
-                          className={cn(
-                            "text-end text-sm font-semibold",
-                            "motion-safe:transition-colors motion-safe:duration-300",
-                            isActive
-                              ? "text-gray-900 dark:text-white"
-                              : "text-gray-400 dark:text-gray-600"
-                          )}
-                        >
-                          {t(testimonial.nameKey)}
-                        </p>
-                      </div>
+                      >
+                        {t(testimonial.nameKey)}
+                      </p>
                     </div>
-                  </CarouselItem>
-                );
-              })}
-            </CarouselContent>
-          </Carousel>
-        </motion.div>
+                  </div>
+                </CarouselItem>
+              );
+            })}
+          </CarouselContent>
+        </Carousel>
+      </motion.div>
 
+      <div className="container relative mx-auto max-w-7xl">
         {/* Dot navigation */}
         {count > 0 && (
           <div className="flex flex-col items-center gap-2 mt-4">

--- a/src/pages/landing/sections/TestimonialsSection.tsx
+++ b/src/pages/landing/sections/TestimonialsSection.tsx
@@ -44,6 +44,10 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
     };
   }, [api]);
 
+  useEffect(() => {
+    api?.reInit();
+  }, [api, isRtl]);
+
   const scrollTo = useCallback(
     (index: number) => {
       api?.scrollTo(index);
@@ -83,15 +87,14 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
             opts={{
               align: "center",
               loop: true,
-              // Keep Embla mechanics LTR, mirroring ScreenshotCarousel.
-              direction: "ltr",
+              direction: isRtl ? "rtl" : "ltr",
             }}
             setApi={setApi}
           >
             {/* py-8 gives vertical breathing room for the active card's shadow. */}
             <CarouselContent
-              className="-ml-4 py-8"
-              style={{ direction: "ltr" }}
+              className="py-8 !-ms-4 !ml-0"
+              style={{ direction: isRtl ? "rtl" : "ltr" }}
             >
               {testimonials.map((testimonial, index) => {
                 const isActive = index === selectedIndex;
@@ -99,7 +102,7 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
                   // Fixed height prevents section height from jumping between cards.
                   <CarouselItem
                     key={index}
-                    className="pl-4 basis-[85%] sm:basis-[60%] lg:basis-[38%] h-64 sm:h-60"
+                    className="!ps-4 !pl-0 basis-[85%] sm:basis-[60%] lg:basis-[38%] h-64 sm:h-60"
                   >
                     <div
                       dir={i18n.dir()}

--- a/src/pages/landing/sections/TestimonialsSection.tsx
+++ b/src/pages/landing/sections/TestimonialsSection.tsx
@@ -55,7 +55,7 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
     <section
       id="testimonials"
       ref={sectionRef}
-      className="py-20 px-4 bg-white dark:bg-gray-800"
+      className="overflow-x-hidden py-20 px-4 bg-white dark:bg-gray-800"
     >
       <div className="container relative mx-auto max-w-7xl">
         {/* Section heading */}
@@ -79,7 +79,7 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
           transition={{ type: "spring", damping: 22, stiffness: 280, delay: 0.15 }}
         >
           <Carousel
-            className="w-full [&>div:first-child]:overflow-visible"
+            className="w-full"
             opts={{
               align: "center",
               loop: true,

--- a/src/pages/landing/sections/TestimonialsSection.tsx
+++ b/src/pages/landing/sections/TestimonialsSection.tsx
@@ -70,100 +70,98 @@ export const TestimonialsSection: React.FC<TestimonialsSectionProps> = ({
             {t("testimonials.title")}
           </motion.h2>
         </div>
-      </div>
 
-      {/* Full-width carousel so side cards can peek without hard clipping */}
-      <motion.div
-        initial={{ opacity: 0, y: 32 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true, margin: "0px 0px -80px 0px" }}
-        transition={{ type: "spring", damping: 22, stiffness: 280, delay: 0.15 }}
-      >
-        <Carousel
-          className="w-full [&>div:first-child]:overflow-visible"
-          opts={{
-            align: "center",
-            loop: true,
-            // Keep Embla mechanics LTR, mirroring ScreenshotCarousel.
-            direction: "ltr",
-          }}
-          setApi={setApi}
+        {/* Carousel */}
+        <motion.div
+          initial={{ opacity: 0, y: 32 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true, margin: "0px 0px -80px 0px" }}
+          transition={{ type: "spring", damping: 22, stiffness: 280, delay: 0.15 }}
         >
-          {/* py-8 gives vertical breathing room for the active card's shadow. */}
-          <CarouselContent
-            className="-ml-4 py-8"
-            style={{ direction: "ltr" }}
+          <Carousel
+            className="w-full [&>div:first-child]:overflow-visible"
+            opts={{
+              align: "center",
+              loop: true,
+              // Keep Embla mechanics LTR, mirroring ScreenshotCarousel.
+              direction: "ltr",
+            }}
+            setApi={setApi}
           >
-            {testimonials.map((testimonial, index) => {
-              const isActive = index === selectedIndex;
-              return (
-                // Fixed height prevents section height from jumping between cards.
-                <CarouselItem
-                  key={index}
-                  className="pl-4 basis-[85%] sm:basis-[60%] lg:basis-[38%] h-64 sm:h-60"
-                >
-                  <div
-                    dir={i18n.dir()}
-                    className={cn(
-                      "flex flex-col h-full rounded-2xl border p-7",
-                      // Only transition compositor-friendly properties, not layout.
-                      "motion-safe:transition-[transform,opacity,box-shadow,border-color]",
-                      "motion-safe:duration-500 motion-safe:ease-out",
-                      "will-change-transform",
-                      isActive
-                        ? "bg-white dark:bg-gray-900 border-emerald-200 dark:border-emerald-800 shadow-[0_8px_40px_-8px_rgba(16,185,129,0.22)] dark:shadow-[0_8px_40px_-8px_rgba(16,185,129,0.18)] scale-[1.03] opacity-100"
-                        : "bg-gray-50 dark:bg-gray-900/50 border-gray-200 dark:border-gray-800 shadow-sm scale-[0.92] opacity-65"
-                    )}
+            {/* py-8 gives vertical breathing room for the active card's shadow. */}
+            <CarouselContent
+              className="-ml-4 py-8"
+              style={{ direction: "ltr" }}
+            >
+              {testimonials.map((testimonial, index) => {
+                const isActive = index === selectedIndex;
+                return (
+                  // Fixed height prevents section height from jumping between cards.
+                  <CarouselItem
+                    key={index}
+                    className="pl-4 basis-[85%] sm:basis-[60%] lg:basis-[38%] h-64 sm:h-60"
                   >
-                    {/* Quote icon */}
-                    <Quote
+                    <div
+                      dir={i18n.dir()}
                       className={cn(
-                        "w-6 h-6 mb-3 shrink-0",
-                        "motion-safe:transition-colors motion-safe:duration-300",
+                        "flex flex-col h-full rounded-2xl border p-7",
+                        // Only transition compositor-friendly properties, not layout.
+                        "motion-safe:transition-[transform,opacity,box-shadow,border-color]",
+                        "motion-safe:duration-500 motion-safe:ease-out",
+                        "will-change-transform",
                         isActive
-                          ? "text-emerald-500 dark:text-emerald-400"
-                          : "text-gray-300 dark:text-gray-700"
+                          ? "bg-white dark:bg-gray-900 border-emerald-200 dark:border-emerald-800 shadow-[0_8px_40px_-8px_rgba(16,185,129,0.22)] dark:shadow-[0_8px_40px_-8px_rgba(16,185,129,0.18)] scale-[1.03] opacity-100"
+                          : "bg-gray-50 dark:bg-gray-900/50 border-gray-200 dark:border-gray-800 shadow-sm scale-[0.92] opacity-65"
                       )}
-                      aria-hidden="true"
-                    />
-
-                    <div className="flex flex-1 items-center justify-center overflow-hidden">
-                      <p
+                    >
+                      {/* Quote icon */}
+                      <Quote
                         className={cn(
-                          "leading-relaxed text-center",
-                          "motion-safe:transition-[color,opacity] motion-safe:duration-300",
-                          isActive
-                            ? "text-gray-800 dark:text-gray-100 text-base md:text-lg opacity-100"
-                            : "text-gray-500 dark:text-gray-400 text-sm md:text-base opacity-80"
-                        )}
-                      >
-                        {t(testimonial.textKey)}
-                      </p>
-                    </div>
-
-                    {/* Name uses text-end: left in Hebrew, right in English, like a signature. */}
-                    <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
-                      <p
-                        className={cn(
-                          "text-end text-sm font-semibold",
+                          "w-6 h-6 mb-3 shrink-0",
                           "motion-safe:transition-colors motion-safe:duration-300",
                           isActive
-                            ? "text-gray-900 dark:text-white"
-                            : "text-gray-400 dark:text-gray-600"
+                            ? "text-emerald-500 dark:text-emerald-400"
+                            : "text-gray-300 dark:text-gray-700"
                         )}
-                      >
-                        {t(testimonial.nameKey)}
-                      </p>
-                    </div>
-                  </div>
-                </CarouselItem>
-              );
-            })}
-          </CarouselContent>
-        </Carousel>
-      </motion.div>
+                        aria-hidden="true"
+                      />
 
-      <div className="container relative mx-auto max-w-7xl">
+                      <div className="flex flex-1 items-center justify-center overflow-hidden">
+                        <p
+                          className={cn(
+                            "leading-relaxed text-center",
+                            "motion-safe:transition-[color,opacity] motion-safe:duration-300",
+                            isActive
+                              ? "text-gray-800 dark:text-gray-100 text-base md:text-lg opacity-100"
+                              : "text-gray-500 dark:text-gray-400 text-sm md:text-base opacity-80"
+                          )}
+                        >
+                          {t(testimonial.textKey)}
+                        </p>
+                      </div>
+
+                      {/* Name uses text-end: left in Hebrew, right in English, like a signature. */}
+                      <div className="mt-4 pt-4 border-t border-gray-100 dark:border-gray-800">
+                        <p
+                          className={cn(
+                            "text-end text-sm font-semibold",
+                            "motion-safe:transition-colors motion-safe:duration-300",
+                            isActive
+                              ? "text-gray-900 dark:text-white"
+                              : "text-gray-400 dark:text-gray-600"
+                          )}
+                        >
+                          {t(testimonial.nameKey)}
+                        </p>
+                      </div>
+                    </div>
+                  </CarouselItem>
+                );
+              })}
+            </CarouselContent>
+          </Carousel>
+        </motion.div>
+
         {/* Dot navigation */}
         {count > 0 && (
           <div className="flex flex-col items-center gap-2 mt-4">


### PR DESCRIPTION
## Summary
- Removes the `overflow-visible` override on the testimonials Embla carousel wrapper that let slides extend past the viewport
- Adds `overflow-x-hidden` on the testimonials section as a safety net for scale/shadow overflow

## Test plan
- [ ] Open the landing page and scroll to the testimonials section
- [ ] Swipe/click through carousel slides on mobile and desktop
- [ ] Confirm the page no longer gains horizontal scroll
- [ ] Confirm carousel navigation and active-card styling still look correct