### PR TITLE
chore: remove stagewise.json, dotenv, and fix stale README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Output files will be in `src-tauri/target/release/bundle/`.
 - `src/`: Frontend React/TypeScript source code.
   - `components/`: Reusable UI components.
   - `contexts/`: React Context providers (e.g., `PlatformContext`).
-  - `lib/`: Utility functions, services (`dataService.ts`, `store.ts`), and core logic (`tithe-calculator.ts`).
+  - `lib/`: Utility functions, state (`store.ts`), and backend-access services (`data-layer/`).
   - `pages/`: Page-level components.
   - `types/`: TypeScript type definitions (e.g., `Transaction.ts`).
   - `main.tsx`: Application entry point.
@@ -126,15 +126,15 @@ All financial events (income, expenses, donations) are represented by a single `
 
 ### State Management
 
-Zustand (`src/lib/store.ts`) is used for global state management. The primary piece of state is the `transactions: Transaction[]` array, which holds all financial records. Key statistics and the required tithe balance are fetched from the server (Supabase RPC or Tauri/SQLite); client-side selectors such as `selectCalculatedBalance` remain available for fallback and compatibility.
+Zustand (`src/lib/store.ts`) is used for global state management: user settings and the server-calculated tithe/income/expense/donation figures. There is no client-side transactions array or client-side balance calculation — all financial totals are computed server-side (Supabase RPC for web, SQLite via Tauri commands for desktop) and read directly into the store.
 
 ### Data Flow
 
-Data is loaded from the respective database into the Zustand store on application startup (conditional on user authentication for the web version). UI interactions manipulate the Zustand store, and changes are persisted back to the database via `dataService.ts`.
+All backend reads and writes go through `src/lib/data-layer/` (a set of per-domain services, e.g. `transactions.service.ts`, `stats.service.ts`), which branch by platform to call either a Supabase RPC or a Tauri command. UI interactions call these services directly or update the Zustand store with the results.
 
 ### Data Import/Export (Desktop)
 
-The desktop application supports exporting all transaction data to a JSON file and importing data from such a file, overwriting existing data after user confirmation. This functionality is managed in `src/lib/dataManagement.ts` and accessible via the Settings page.
+The desktop application supports exporting all transaction data to a JSON file and importing data from such a file, overwriting existing data after user confirmation. This functionality is managed in `src/lib/data-layer/dataManagement/` and accessible via the Settings page.
 
 ## Multi-Language, Theming, and Responsiveness
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
         "autoprefixer": "^10.4.23",
-        "dotenv": "^17.2.3",
         "eslint": "^9.39.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.26",
@@ -7227,19 +7226,6 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
     "autoprefixer": "^10.4.23",
-    "dotenv": "^17.2.3",
     "eslint": "^9.39.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.26",

--- a/stagewise.json
+++ b/stagewise.json
@@ -1,6 +1,0 @@
-{
-  "port": 3100,
-  "appPort": 5173,
-  "autoPlugins": true,
-  "plugins": []
-}


### PR DESCRIPTION
Small cleanup, closes out the last 3 open items from the cleanup plan's red-flag list.

- **`stagewise.json`** removed — zero references anywhere in the codebase; leftover config for an external browser-to-IDE dev tool. Confirmed with Yossi it's no longer used.
- **`dotenv`** removed from devDependencies — no `import`/`require` anywhere in `src/` or `scripts/`. Vite already loads `.env` natively via `import.meta.env`; the separate package was unused.
- **README.md** "Data Management" section updated — it still described the pre-migration architecture (`dataService.ts`, `tithe-calculator.ts`, a client-side `transactions: Transaction[]` array, `selectCalculatedBalance`). Verified directly against current `src/lib/store.ts`: none of these exist anymore. All financial totals are server-calculated (Supabase RPC / Tauri+SQLite) and read through `src/lib/data-layer/` services — the migration described in `data-flow-server-calculations-and-cleanup.md` is fully complete.

### Verification
76/76 tests green, `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)