### PR TITLE
refactor(profile): move ProfilePage DB access into profile.service

### DIFF
--- a/llm-instructions/features/email/email-reminders-feature-complete-guide.md
+++ b/llm-instructions/features/email/email-reminders-feature-complete-guide.md
@@ -522,7 +522,7 @@ SELECT cron.schedule(
   '0 18 * * *', -- Daily at 18:00 UTC (20:00 Israel time)
   'SELECT net.http_post(
     url:=''https://flpzqbvbymoluoeeeofg.supabase.co/functions/v1/send-reminder-emails'',
-    headers:=''{"Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImZscHpxYnZieW1vbHVvZWVlb2ZnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU3NTk2NDQsImV4cCI6MjA2MTMzNTY0NH0.wSymW37g5ekcgZec1RkPbufTp60pokmUQF3V6L663Wo"}'',
+    headers:=''{"Authorization": "Bearer YOUR_ANON_KEY"}'',
     body:=''{}''
   );'
 );

--- a/src/lib/data-layer/profile.service.test.ts
+++ b/src/lib/data-layer/profile.service.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockSingle = vi.fn();
 const mockGetPublicUrl = vi.fn();
+const mockUpdate = vi.fn();
+const mockUpdateEq = vi.fn();
 
 vi.mock("@/lib/supabaseClient", () => ({
   supabase: {
@@ -9,6 +11,12 @@ vi.mock("@/lib/supabaseClient", () => ({
       select: () => ({
         eq: () => ({ single: (...args: unknown[]) => mockSingle(...args) }),
       }),
+      update: (...args: unknown[]) => {
+        mockUpdate(...args);
+        return {
+          eq: (...eqArgs: unknown[]) => mockUpdateEq(...eqArgs),
+        };
+      },
     }),
     storage: {
       from: () => ({ getPublicUrl: (...args: unknown[]) => mockGetPublicUrl(...args) }),
@@ -16,7 +24,11 @@ vi.mock("@/lib/supabaseClient", () => ({
   },
 }));
 
-import { fetchUserProfileDisplay } from "./profile.service";
+import {
+  fetchUserProfileDisplay,
+  fetchProfileFullName,
+  updateProfileFullName,
+} from "./profile.service";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -61,5 +73,51 @@ describe("fetchUserProfileDisplay", () => {
   it("throws on a real fetch error (non-406)", async () => {
     mockSingle.mockResolvedValue({ data: null, error: { message: "network error" }, status: 500 });
     await expect(fetchUserProfileDisplay("u1")).rejects.toEqual({ message: "network error" });
+  });
+});
+
+describe("fetchProfileFullName", () => {
+  it("returns the full_name string from the profile row", async () => {
+    mockSingle.mockResolvedValue({
+      data: { full_name: "Yossi Weinberger" },
+      error: null,
+      status: 200,
+    });
+    await expect(fetchProfileFullName("u1")).resolves.toBe("Yossi Weinberger");
+  });
+
+  it("returns an empty string when full_name is null", async () => {
+    mockSingle.mockResolvedValue({ data: { full_name: null }, error: null, status: 200 });
+    await expect(fetchProfileFullName("u1")).resolves.toBe("");
+  });
+
+  it("treats a 406 (no row) as an empty name", async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: "no rows" }, status: 406 });
+    await expect(fetchProfileFullName("u1")).resolves.toBe("");
+  });
+
+  it("throws on a real fetch error (non-406)", async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: "network error" }, status: 500 });
+    await expect(fetchProfileFullName("u1")).rejects.toEqual({ message: "network error" });
+  });
+});
+
+describe("updateProfileFullName", () => {
+  it("updates full_name and resolves when Supabase succeeds", async () => {
+    mockUpdateEq.mockResolvedValue({ error: null });
+    await expect(updateProfileFullName("u1", "New Name")).resolves.toBeUndefined();
+    expect(mockUpdate).toHaveBeenCalledWith({ full_name: "New Name" });
+    expect(mockUpdateEq).toHaveBeenCalledWith("id", "u1");
+  });
+
+  it("stores an empty name as null", async () => {
+    mockUpdateEq.mockResolvedValue({ error: null });
+    await updateProfileFullName("u1", "");
+    expect(mockUpdate).toHaveBeenCalledWith({ full_name: null });
+  });
+
+  it("throws when the update fails", async () => {
+    mockUpdateEq.mockResolvedValue({ error: { message: "rls denied" } });
+    await expect(updateProfileFullName("u1", "X")).rejects.toEqual({ message: "rls denied" });
   });
 });

--- a/src/lib/data-layer/profile.service.test.ts
+++ b/src/lib/data-layer/profile.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockSingle = vi.fn();
 const mockGetPublicUrl = vi.fn();
+const mockSelectEq = vi.fn();
 const mockUpdate = vi.fn();
 const mockUpdateEq = vi.fn();
 
@@ -9,7 +10,10 @@ vi.mock("@/lib/supabaseClient", () => ({
   supabase: {
     from: () => ({
       select: () => ({
-        eq: () => ({ single: (...args: unknown[]) => mockSingle(...args) }),
+        eq: (...eqArgs: unknown[]) => {
+          mockSelectEq(...eqArgs);
+          return { single: (...args: unknown[]) => mockSingle(...args) };
+        },
       }),
       update: (...args: unknown[]) => {
         mockUpdate(...args);
@@ -84,6 +88,7 @@ describe("fetchProfileFullName", () => {
       status: 200,
     });
     await expect(fetchProfileFullName("u1")).resolves.toBe("Yossi Weinberger");
+    expect(mockSelectEq).toHaveBeenCalledWith("id", "u1");
   });
 
   it("returns an empty string when full_name is null", async () => {

--- a/src/lib/data-layer/profile.service.ts
+++ b/src/lib/data-layer/profile.service.ts
@@ -34,3 +34,36 @@ export async function fetchUserProfileDisplay(userId: string): Promise<UserProfi
 
   return { fullName, avatarUrl };
 }
+
+/**
+ * Web-only: loads `full_name` for the profile edit form.
+ * Treats a missing row (406) as an empty name instead of throwing.
+ */
+export async function fetchProfileFullName(userId: string): Promise<string> {
+  const { data, error, status } = await supabase
+    .from("profiles")
+    .select("full_name")
+    .eq("id", userId)
+    .single();
+
+  if (error && status !== 406) {
+    throw error;
+  }
+
+  return data?.full_name ?? "";
+}
+
+/**
+ * Web-only: updates `full_name` on the `profiles` table.
+ * Pass an empty string to clear the name (stored as null).
+ */
+export async function updateProfileFullName(userId: string, fullName: string): Promise<void> {
+  const { error } = await supabase
+    .from("profiles")
+    .update({ full_name: fullName || null })
+    .eq("id", userId);
+
+  if (error) {
+    throw error;
+  }
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -12,10 +12,14 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 import { toast } from "sonner";
-import { useAuth } from "@/contexts/AuthContext"; // Import useAuth
+import { useAuth } from "@/contexts/AuthContext";
 import { logger } from "@/lib/logger";
 import { usePlatform } from "@/contexts/PlatformContext";
 import { syncPostHogUserIdentity } from "@/lib/analytics/posthogIdentity.service";
+import {
+  fetchProfileFullName,
+  updateProfileFullName,
+} from "@/lib/data-layer/profile.service";
 
 export function ProfilePage() {
   const { t, i18n } = useTranslation(["auth", "common"]);
@@ -48,22 +52,13 @@ export function ProfilePage() {
 
     const fetchProfile = async () => {
       try {
-        const { data, error, status } = await supabase
-          .from("profiles")
-          .select("full_name")
-          .eq("id", user.id)
-          .single();
-
-        if (error && status !== 406) {
-          throw error;
-        }
+        const fetchedFullName = await fetchProfileFullName(user.id);
 
         if (isMounted) {
-          const fetchedFullName = data?.full_name ?? "";
           setFullName(fetchedFullName);
           setInitialFullName(fetchedFullName);
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         logger.error("Error loading profile details:", error);
         if (isMounted) {
           toast.error(t("profile.loadError"));
@@ -103,12 +98,7 @@ export function ProfilePage() {
 
     try {
       if (fullNameChanged) {
-        const { error } = await supabase
-          .from("profiles")
-          .update({ full_name: trimmedFullName || null })
-          .eq("id", user.id);
-
-        if (error) throw error;
+        await updateProfileFullName(user.id, trimmedFullName);
         setInitialFullName(trimmedFullName);
       }
 
@@ -126,7 +116,7 @@ export function ProfilePage() {
         setUserInfoRefreshKey((prev) => prev + 1);
         void syncPostHogUserIdentity(user, i18n.language);
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       logger.error("Error updating profile details:", error);
       toast.error(t("profile.personalDetails.saveError"));
     } finally {


### PR DESCRIPTION
## Summary
- Move ProfilePage `profiles` table read/write into `profile.service` (same pattern as UserInfoDisplay)
- Add tests for `fetchProfileFullName` and `updateProfileFullName`
- Redact hardcoded Supabase anon key from email reminders guide (was still in main after closing #242)

## Test plan
- [ ] `npx vitest run src/lib/data-layer/profile.service.test.ts` (12 tests)
- [ ] Web: open Profile page, load name, save name change
- [ ] Web: email/password update still works for email users
- [ ] Desktop: Profile page still loads without web profile fetch errors