### PR TITLE
fix: implement desktop update check hook and remove legacy update logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,10 +20,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import { setPlatform as setGlobalPlatform } from "./lib/platformManager";
 import { useDonationStore } from "./lib/store";
 import { checkAndSendDesktopReminder } from "./lib/data-layer/reminders";
-import { checkForUpdates } from "./lib/data-layer/updater.service";
 import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils/index";
-import { toast } from "sonner";
 import ContactFAB from "./components/layout/ContactFAB";
 import { TermsAcceptanceModal } from "./components/auth/TermsAcceptanceModal";
 import { WhatsNewModal } from "./components/WhatsNewModal";
@@ -41,6 +39,7 @@ import {
 } from "./lib/security/appLock.service";
 import { DesktopLockScreen } from "./components/security/DesktopLockScreen";
 import { useSettingsSync } from "./hooks/useSettingsSync";
+import { useDesktopUpdateCheck } from "./hooks/useDesktopUpdateCheck";
 import { useMediaQuery } from "./hooks/use-media-query";
 
 export type DesktopLockStatus =
@@ -189,22 +188,6 @@ function App() {
           })
           .then(() => {
             logger.log("Desktop reminder check complete.");
-            return checkForUpdates();
-          })
-          .then(async (updateInfo) => {
-            if (updateInfo) {
-              logger.log(`Update available: ${updateInfo.version}`);
-              await i18n.loadNamespaces("settings");
-              toast.info(
-                tRef.current("versionInfo.updateAvailable", {
-                  version: updateInfo.version,
-                  ns: "settings",
-                }),
-                { duration: 5000 }
-              );
-            } else {
-              logger.log("App is up to date");
-            }
           })
           .catch((error) =>
             logger.error("Error during desktop initialization sequence:", error)
@@ -218,6 +201,8 @@ function App() {
         setDesktopInitComplete(true);
       });
   }, [platform, desktopLockStatus]);
+
+  useDesktopUpdateCheck(platform, desktopInitComplete);
 
   // Desktop: auto-lock after real user inactivity (mouse/keyboard/touch/etc.)
   useEffect(() => {

--- a/src/hooks/useDesktopUpdateCheck.ts
+++ b/src/hooks/useDesktopUpdateCheck.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  checkForUpdates,
+  downloadAndInstallUpdate,
+} from "@/lib/data-layer/updater.service";
+import { logger } from "@/lib/logger";
+import type { Platform } from "@/contexts/PlatformContext";
+
+const FORCE_UPDATE_TOAST_KEY = "ten10:forceUpdateToast";
+
+/**
+ * After the desktop shell (and Toaster) is mounted, check for updates and
+ * show a top-center toast with an install action when one is available.
+ *
+ * DEV: localStorage.setItem("ten10:forceUpdateToast", "9.9.9") then reload.
+ */
+export function useDesktopUpdateCheck(
+  platform: Platform,
+  desktopInitComplete: boolean
+) {
+  const { i18n, t } = useTranslation();
+  const tRef = useRef(t);
+  tRef.current = t;
+
+  useEffect(() => {
+    if (platform !== "desktop" || !desktopInitComplete) return;
+
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const forcedVersion = import.meta.env.DEV
+          ? localStorage.getItem(FORCE_UPDATE_TOAST_KEY)
+          : null;
+
+        const updateInfo = forcedVersion
+          ? { version: forcedVersion, date: new Date().toISOString() }
+          : await checkForUpdates();
+
+        if (cancelled) return;
+        if (!updateInfo) {
+          logger.log("App is up to date");
+          return;
+        }
+
+        logger.log(`Update available: ${updateInfo.version}`);
+        await i18n.loadNamespaces("settings");
+        if (cancelled) return;
+
+        toast.info(
+          tRef.current("versionInfo.updateAvailable", {
+            version: updateInfo.version,
+            ns: "settings",
+          }),
+          {
+            duration: 15000,
+            position: "top-center",
+            action: {
+              label: tRef.current("versionInfo.installButton", {
+                ns: "settings",
+              }),
+              onClick: () => {
+                const toastId = toast.loading(
+                  tRef.current("versionInfo.downloading", { ns: "settings" })
+                );
+                void downloadAndInstallUpdate()
+                  .then(() => {
+                    toast.success(
+                      tRef.current("versionInfo.installSuccess", {
+                        ns: "settings",
+                      }),
+                      { id: toastId }
+                    );
+                  })
+                  .catch((error) => {
+                    logger.error("Failed to install update from toast:", error);
+                    toast.error(
+                      tRef.current("versionInfo.installError", {
+                        ns: "settings",
+                      }),
+                      { id: toastId }
+                    );
+                  });
+              },
+            },
+          }
+        );
+      } catch (error) {
+        logger.error("Failed to check for updates:", error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [platform, desktopInitComplete, i18n]);
+}


### PR DESCRIPTION
- Added `useDesktopUpdateCheck` hook to manage update checks for the desktop platform.
- Removed outdated update checking logic from the `App` component.
- Integrated toast notifications for update availability and installation actions.