### PR TITLE
fix(settings): sync email toggle with consent columns

### DIFF
--- a/llm-instructions/features/email/email-reminders-feature-complete-guide.md
+++ b/llm-instructions/features/email/email-reminders-feature-complete-guide.md
@@ -119,41 +119,25 @@ The reminder settings are integrated into the existing settings page:
 **File**: `src/components/settings/NotificationSettingsCard.tsx`
 
 ```typescript
-interface NotificationSettingsCardProps {
-  reminderEnabled: boolean;
-  reminderDayOfMonth: number;
-  onReminderEnabledChange: (enabled: boolean) => void;
-  onReminderDayChange: (day: number) => void;
-}
-
-// Key features:
-// - Toggle switch for enabling/disabling reminders
-// - When enabled/disabled, it syncs both `reminder_enabled` and `mailing_list_consent` in the database (for web users)
-// - Day selector with 4 preset options
-// - Platform-specific messaging (web vs desktop)
-// - RTL/LTR support for Hebrew/English
+// Key behavior:
+// - Toggle ON only when reminderEnabled && mailingListConsent
+//   (unsubscribe may clear either column without updating client_preferences.notifications)
+// - Turning the toggle on/off writes both reminder_enabled and mailing_list_consent (web)
+// - Day selector uses the same AND for enabled/disabled state
+// - Platform-specific messaging (web email vs desktop notifications)
 ```
+
+**Related files**:
+
+- `src/pages/SettingsPage.tsx` — writes only changed profile columns on toggle/day change
+- `src/lib/services/preferences-sync.service.ts` — on login sync, sets local `notifications` from `reminder_enabled && mailing_list_consent`
 
 ### State Management
 
-The reminder settings are managed through the Zustand store:
+The reminder settings are managed through the Zustand store (`src/lib/store.ts`) as flat fields on `Settings`:
 
-**File**: `src/lib/store.ts`
-
-```typescript
-interface Settings {
-  // ... existing settings
-  reminderSettings: {
-    enabled: boolean;
-    dayOfMonth: 1 | 10 | 15 | 20;
-  };
-}
-
-// Actions:
-// - setReminderEnabled(enabled: boolean)
-// - setReminderDayOfMonth(day: number)
-// - saveSettings() // Persists to localStorage and Supabase
-```
+- `reminderEnabled`, `reminderDayOfMonth`, `mailingListConsent`
+- `notifications` — UI/local mirror; for email, treat the dedicated columns as source of truth after sync
 
 ### Translation Support
 

--- a/llm-instructions/features/email/email-reminders-feature-complete-guide.md
+++ b/llm-instructions/features/email/email-reminders-feature-complete-guide.md
@@ -120,10 +120,11 @@ The reminder settings are integrated into the existing settings page:
 
 ```typescript
 // Key behavior:
-// - Toggle ON only when reminderEnabled && mailingListConsent
+// - Web: toggle ON only when reminderEnabled && mailingListConsent
 //   (unsubscribe may clear either column without updating client_preferences.notifications)
-// - Turning the toggle on/off writes both reminder_enabled and mailing_list_consent (web)
-// - Day selector uses the same AND for enabled/disabled state
+// - Desktop: toggle follows reminderEnabled only (local reminders ignore mailing consent)
+// - Turning the toggle on/off writes both reminder_enabled and mailing_list_consent (web DB)
+// - Day selector uses the same platform-specific ON state
 // - Platform-specific messaging (web email vs desktop notifications)
 ```
 

--- a/llm-instructions/features/email/email-unsubscribe-system-guide.md
+++ b/llm-instructions/features/email/email-unsubscribe-system-guide.md
@@ -172,6 +172,16 @@ mailing_list_consent = false →
 "הוסרת מרשימת התפוצה שלנו"
 ```
 
+### 2.1 סנכרון טוגל ההגדרות אחרי unsubscribe
+
+Unsubscribe מעדכן רק עמודות ייעודיות ב־`profiles` (`reminder_enabled` / `mailing_list_consent`), לא את `client_preferences.notifications`.
+
+כדי שהטוגל בהגדרות ישקף את מצב המייל האמיתי:
+
+- **תצוגה**: `NotificationSettingsCard` מציג ON רק כש־`reminderEnabled && mailingListConsent`
+- **סנכרון**: `PreferencesSyncService` גוזר `notifications` מאותו AND אחרי טעינת העמודות מה־DB
+- **כתיבה**: הפעלת הטוגל כותבת גם `reminder_enabled` וגם `mailing_list_consent` (רק השדות שהשתנו)
+
 ### 3. One-Click Unsubscribe (עתידי)
 
 ```
@@ -193,6 +203,8 @@ mailing_list_consent = false →
 
 - `src/pages/UnsubscribePage.tsx` - React page; one `functions.invoke("verify-unsubscribe-token")`
 - `supabase/functions/verify-unsubscribe-token/index.ts` - verifies JWT and applies preference update with `SUPABASE_SERVICE_ROLE_KEY`
+- `src/components/settings/NotificationSettingsCard.tsx` - toggle ON iff `reminderEnabled && mailingListConsent`
+- `src/lib/services/preferences-sync.service.ts` - derives local `notifications` from those columns on sync
 
 ### 3. Database Functions
 

--- a/llm-instructions/features/email/email-unsubscribe-system-guide.md
+++ b/llm-instructions/features/email/email-unsubscribe-system-guide.md
@@ -178,7 +178,8 @@ Unsubscribe מעדכן רק עמודות ייעודיות ב־`profiles` (`remin
 
 כדי שהטוגל בהגדרות ישקף את מצב המייל האמיתי:
 
-- **תצוגה**: `NotificationSettingsCard` מציג ON רק כש־`reminderEnabled && mailingListConsent`
+- **תצוגה (web)**: `NotificationSettingsCard` מציג ON רק כש־`reminderEnabled && mailingListConsent`
+- **תצוגה (desktop)**: הטוגל מבוסס על `reminderEnabled` בלבד (תזכורות מקומיות לא תלויות ב־mailing consent)
 - **סנכרון**: `PreferencesSyncService` גוזר `notifications` מאותו AND אחרי טעינת העמודות מה־DB
 - **כתיבה**: הפעלת הטוגל כותבת גם `reminder_enabled` וגם `mailing_list_consent` (רק השדות שהשתנו)
 
@@ -203,7 +204,7 @@ Unsubscribe מעדכן רק עמודות ייעודיות ב־`profiles` (`remin
 
 - `src/pages/UnsubscribePage.tsx` - React page; one `functions.invoke("verify-unsubscribe-token")`
 - `supabase/functions/verify-unsubscribe-token/index.ts` - verifies JWT and applies preference update with `SUPABASE_SERVICE_ROLE_KEY`
-- `src/components/settings/NotificationSettingsCard.tsx` - toggle ON iff `reminderEnabled && mailingListConsent`
+- `src/components/settings/NotificationSettingsCard.tsx` - web: ON iff both columns; desktop: `reminderEnabled` only
 - `src/lib/services/preferences-sync.service.ts` - derives local `notifications` from those columns on sync
 
 ### 3. Database Functions

--- a/src/components/settings/NotificationSettingsCard.tsx
+++ b/src/components/settings/NotificationSettingsCard.tsx
@@ -66,6 +66,12 @@ export function NotificationSettingsCard({
     setAutostartStatus(enabled);
   };
 
+  // Emails only go out when both columns are true; unsubscribe may clear either.
+  const emailNotificationsOn = Boolean(
+    notificationSettings.reminderEnabled &&
+      notificationSettings.mailingListConsent,
+  );
+
   return (
     <Card className={disabled ? "opacity-50 pointer-events-none" : ""}>
       <CardHeader>
@@ -108,7 +114,7 @@ export function NotificationSettingsCard({
             </div>
           </div>
           <Switch
-            checked={notificationSettings.notifications}
+            checked={emailNotificationsOn}
             onCheckedChange={(checked) =>
               updateSettings({
                 notifications: checked,
@@ -130,7 +136,7 @@ export function NotificationSettingsCard({
               <button
                 key={day}
                 onClick={() => handleDayChange(day)}
-                disabled={disabled || !notificationSettings.notifications}
+                disabled={disabled || !emailNotificationsOn}
                 className={`
                   px-2 py-2 text-xs sm:text-sm font-medium rounded-md border transition-colors
                   ${
@@ -139,7 +145,7 @@ export function NotificationSettingsCard({
                       : "bg-background text-foreground border-border hover:bg-accent hover:text-accent-foreground"
                   }
                   ${
-                    disabled || !notificationSettings.notifications
+                    disabled || !emailNotificationsOn
                       ? "opacity-50 cursor-not-allowed"
                       : "cursor-pointer"
                   }

--- a/src/components/settings/NotificationSettingsCard.tsx
+++ b/src/components/settings/NotificationSettingsCard.tsx
@@ -66,11 +66,13 @@ export function NotificationSettingsCard({
     setAutostartStatus(enabled);
   };
 
-  // Emails only go out when both columns are true; unsubscribe may clear either.
-  const emailNotificationsOn = Boolean(
-    notificationSettings.reminderEnabled &&
-      notificationSettings.mailingListConsent,
-  );
+  // Web email needs both columns; desktop reminders only check reminderEnabled.
+  const emailNotificationsOn = isWeb
+    ? Boolean(
+        notificationSettings.reminderEnabled &&
+          notificationSettings.mailingListConsent,
+      )
+    : Boolean(notificationSettings.reminderEnabled);
 
   return (
     <Card className={disabled ? "opacity-50 pointer-events-none" : ""}>

--- a/src/lib/services/preferences-sync.service.ts
+++ b/src/lib/services/preferences-sync.service.ts
@@ -64,6 +64,26 @@ export const PreferencesSyncService = {
         dedicatedColumnUpdates.mailingListConsent = profile.mailing_list_consent;
       }
 
+      // Keep the settings toggle in sync with the real email gate: both
+      // reminder_enabled and mailing_list_consent must be true (unsubscribe
+      // can clear either column without touching client_preferences.notifications).
+      if (
+        profile?.reminder_enabled != null ||
+        profile?.mailing_list_consent != null
+      ) {
+        const effectiveReminder =
+          dedicatedColumnUpdates.reminderEnabled ??
+          localSettings.reminderEnabled ??
+          false;
+        const effectiveConsent =
+          dedicatedColumnUpdates.mailingListConsent ??
+          localSettings.mailingListConsent ??
+          false;
+        dedicatedColumnUpdates.notifications = Boolean(
+          effectiveReminder && effectiveConsent,
+        );
+      }
+
       if (!dbPreferences) {
         // DB is empty (null). Local wins. Push client_preferences to DB.
         // Note: dedicated profile columns (reminder_day_of_month, reminder_enabled,

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -203,10 +203,13 @@ export function SettingsPage() {
                 newNotificationSettings.reminderDayOfMonth;
             }
             if (Object.keys(profileUpdate).length > 0) {
-              await supabase
+              const { error } = await supabase
                 .from("profiles")
                 .update(profileUpdate)
                 .eq("id", user.id);
+              if (error) {
+                throw error;
+              }
             }
           } catch (error) {
             logger.error(

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -168,6 +168,7 @@ export function SettingsPage() {
         recurringDonations: settings.recurringDonations,
         reminderEnabled: settings.reminderEnabled,
         reminderDayOfMonth: settings.reminderDayOfMonth,
+        mailingListConsent: settings.mailingListConsent,
       }}
       updateSettings={async (newNotificationSettings) => {
         // Update local settings immediately
@@ -179,18 +180,34 @@ export function SettingsPage() {
           });
         }
 
-        // Update Supabase for web users
+        // Update Supabase for web users — only fields present in this change
         if (platform === "web" && user) {
           try {
-            await supabase
-              .from("profiles")
-              .update({
-                reminder_enabled: newNotificationSettings.reminderEnabled,
-                mailing_list_consent: newNotificationSettings.reminderEnabled, // Also update mailing list consent
-                reminder_day_of_month:
-                  newNotificationSettings.reminderDayOfMonth,
-              })
-              .eq("id", user.id);
+            const profileUpdate: {
+              reminder_enabled?: boolean;
+              mailing_list_consent?: boolean;
+              reminder_day_of_month?: 1 | 5 | 10 | 15 | 20 | 25;
+            } = {};
+            if (typeof newNotificationSettings.reminderEnabled === "boolean") {
+              profileUpdate.reminder_enabled =
+                newNotificationSettings.reminderEnabled;
+            }
+            if (
+              typeof newNotificationSettings.mailingListConsent === "boolean"
+            ) {
+              profileUpdate.mailing_list_consent =
+                newNotificationSettings.mailingListConsent;
+            }
+            if (newNotificationSettings.reminderDayOfMonth != null) {
+              profileUpdate.reminder_day_of_month =
+                newNotificationSettings.reminderDayOfMonth;
+            }
+            if (Object.keys(profileUpdate).length > 0) {
+              await supabase
+                .from("profiles")
+                .update(profileUpdate)
+                .eq("id", user.id);
+            }
           } catch (error) {
             logger.error(
               "Failed to update reminder settings in Supabase:",


### PR DESCRIPTION
## Summary
- Settings email toggle now reflects `reminder_enabled && mailing_list_consent` (source of truth after unsubscribe).
- `PreferencesSyncService` derives local `notifications` from those columns on sync.
- Settings writes only changed profile fields; docs updated under `llm-instructions/features/email/`.

## Test plan
- [ ] Enable email reminders in settings → both DB columns true, toggle ON
- [ ] Unsubscribe via `type=reminder` → refresh settings → toggle OFF
- [ ] Unsubscribe via `type=all` → refresh settings → toggle OFF
- [ ] Turn toggle back ON → both columns true again
- [ ] Change reminder day only → consent/reminder columns unchanged
