### PR TITLE
fix(db): lock update_user_preferences to service_role

### DIFF
--- a/docs/superpowers/specs/2026-07-15-secure-unsubscribe-flow-design.md
+++ b/docs/superpowers/specs/2026-07-15-secure-unsubscribe-flow-design.md
@@ -1,7 +1,7 @@
 # Secure Unsubscribe Flow Design
 
 Date: 2026-07-15  
-Status: Approved for implementation (user choice: option 1)
+Status: Phase 1 live; Phase 2 grants lockdown implemented
 
 ## Problem
 
@@ -13,22 +13,20 @@ Browser never chooses `user_id`. One Edge Function verifies the JWT and applies 
 
 ## Approach (phased, safe deploy)
 
-### Phase 1 — this change (no DB grant lockdown yet)
+### Phase 1 — done
 
 1. Extend `verify-unsubscribe-token` to:
    - verify HMAC JWT (`JWT_SECRET`)
    - apply preference update via Supabase client with `SUPABASE_SERVICE_ROLE_KEY`
    - resolve unsubscribe `type` from the **signed token payload first**; use body/URL `type` only as fallback
 2. Change `UnsubscribePage` to a single `functions.invoke("verify-unsubscribe-token", { token, type })`.
-3. Do **not** revoke RPC grants in this PR.
+3. Do **not** revoke RPC grants in that PR (EF deploy lags FE / migrations).
 
-Why phase 1 has no migration: migrations auto-push to production on PR open, while Edge Functions deploy on merge to `main`. Locking grants before the new EF is live would break all unsubscribe links.
-
-### Phase 2 — follow-up PR (after smoke on a real unsubscribe link)
+### Phase 2 — this change
 
 Migration: `REVOKE` `update_user_preferences` from `PUBLIC` / `anon` / `authenticated`; `GRANT` to `service_role` only.
 
-Optional cleanup after Phase 2: stop returning `userId` / `email` in the Edge Function JSON (kept in Phase 1 for compatibility with any transitional clients).
+Optional later cleanup: stop returning `userId` / `email` in the Edge Function JSON (kept for transitional clients).
 
 ## Token / type semantics
 

--- a/llm-instructions/backend/supabase-rpc-security-model.md
+++ b/llm-instructions/backend/supabase-rpc-security-model.md
@@ -56,10 +56,10 @@ These require individual review. A privileged function must authenticate or vali
 
 Do not convert such functions to `SECURITY INVOKER` without checking all anonymous and server-side call paths.
 
-### Unsubscribe (Phase 1 / Phase 2)
+### Unsubscribe
 
-- **Phase 1:** `verify-unsubscribe-token` verifies the unsubscribe JWT and calls `update_user_preferences` with `service_role`. The browser must not call that RPC with a client-supplied `p_user_id`.
-- **Phase 2:** lock `update_user_preferences` grants to `service_role` only (after the Phase 1 frontend + Edge Function are live).
+- `verify-unsubscribe-token` verifies the unsubscribe JWT and calls `update_user_preferences` with `service_role`.
+- `update_user_preferences` grants are locked to `service_role` only (Phase 2). The browser must not call that RPC.
 
 ## Migration requirements
 

--- a/llm-instructions/features/email/email-unsubscribe-system-guide.md
+++ b/llm-instructions/features/email/email-unsubscribe-system-guide.md
@@ -19,9 +19,9 @@
 └─────────────────┘
 ```
 
-**Phase 1 (current):** browser calls only the Edge Function; RPC remains callable until Phase 2 locks grants to `service_role`.
+**Phase 1:** browser calls only the Edge Function; apply runs with `service_role`.
 
-**Phase 2 (follow-up):** revoke `EXECUTE` on `update_user_preferences` from `anon` / `authenticated`.
+**Phase 2 (current):** `EXECUTE` on `update_user_preferences` is granted to `service_role` only (`anon` / `authenticated` revoked).
 
 ## רכיבי המערכת
 
@@ -121,7 +121,7 @@ mailing_list_consent BOOLEAN DEFAULT false  -- ביטול הרשמה מוחלט
 - **`update_user_preferences`**: עדכון העדפות משתמש
 
   - פרמטרים: `p_user_id`, `p_reminder_enabled`, `p_mailing_list_consent`
-  - אבטחה: SECURITY DEFINER; after Phase 1 only the Edge Function should call it
+  - אבטחה: SECURITY DEFINER; EXECUTE for `service_role` only (Phase 2)
   - לוגיקה: עדכון רק השדות שסופקו (COALESCE)
 
 - **`get_reminder_users_with_emails`**: שליפת משתמשים לתזכורות
@@ -209,7 +209,7 @@ Unsubscribe מעדכן רק עמודות ייעודיות ב־`profiles` (`remin
 
 ### 3. Database Functions
 
-- `update_user_preferences()` - called by the Edge Function (service_role); must not be called from the browser after Phase 1
+- `update_user_preferences()` - called by the Edge Function (service_role only; anon/authenticated cannot EXECUTE)
 - `get_reminder_users_with_emails()` - שליפת משתמשים
 
 ### 4. Deployment
@@ -399,7 +399,7 @@ MessageHeaders: [
 
 ### פונקציות DB:
 
-- `update_user_preferences(p_user_id, p_reminder_enabled, p_mailing_list_consent)` — נקראת מ־Edge Function (service_role); Phase 2 יינעל ל־service_role בלבד
+- `update_user_preferences(p_user_id, p_reminder_enabled, p_mailing_list_consent)` — Edge Function only (`service_role`); grants locked in Phase 2
 - `get_reminder_users_with_emails(reminder_day)`
 
 ## הוראות תחזוקה
@@ -422,6 +422,6 @@ MessageHeaders: [
 
 ---
 
-**סטטוס**: ✅ **מערכת פעילה** — Phase 1 (verify+apply ב־EF); Phase 2 (lockdown grants) ממתין אחרי smoke  
+**סטטוס**: ✅ **מערכת פעילה** — Phase 1 (verify+apply ב־EF) + Phase 2 (grants ל־service_role בלבד)  
 **תאריך עדכון אחרון**: יולי 2026  
 **נבדק על**: שליחת מיילים + זרימת unsubscribe דרך `verify-unsubscribe-token`

--- a/llm-instructions/features/transactions/transaction-rpc-security.md
+++ b/llm-instructions/features/transactions/transaction-rpc-security.md
@@ -70,9 +70,9 @@ Authorization model (not `SECURITY INVOKER`):
 Web callers: `src/lib/data-layer/analytics.service.ts`, `src/lib/data-layer/stats.service.ts`.
 Server caller: `supabase/functions/send-reminder-emails/user-service.ts`.
 
-## Still excluded (separate flow — Phase 2)
+## Still excluded (separate flow — locked)
 
-- `update_user_preferences(uuid, boolean, boolean)`: Phase 1 moves apply into `verify-unsubscribe-token` (service_role). Grants stay open until a follow-up migration locks the RPC to `service_role` only after the new frontend + Edge Function are live on production.
+- `update_user_preferences(uuid, boolean, boolean)`: remains `SECURITY DEFINER` for the unsubscribe Edge Function. Phase 2 locks `EXECUTE` to `service_role` only; browser clients must not call this RPC.
 
 ## Testing after deployment
 

--- a/supabase/migrations/20260715223000_lock_update_user_preferences_service_role.sql
+++ b/supabase/migrations/20260715223000_lock_update_user_preferences_service_role.sql
@@ -1,0 +1,44 @@
+-- Phase 2: lock update_user_preferences to service_role only.
+-- Prerequisite: Phase 1 is live (verify-unsubscribe-token verifies JWT and
+-- applies this RPC with SUPABASE_SERVICE_ROLE_KEY; browser must not call it).
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.update_user_preferences(uuid, boolean, boolean)') IS NULL THEN
+    RAISE EXCEPTION
+      'Missing function public.update_user_preferences(uuid, boolean, boolean)';
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.update_user_preferences(uuid, boolean, boolean) IS
+  'SECURITY DEFINER preference update for unsubscribe Edge Function; executable by service_role only.';
+
+REVOKE ALL ON FUNCTION public.update_user_preferences(uuid, boolean, boolean)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.update_user_preferences(uuid, boolean, boolean)
+  TO service_role;
+
+DO $$
+DECLARE
+  function_signature text :=
+    'public.update_user_preferences(uuid, boolean, boolean)';
+BEGIN
+  IF to_regprocedure(function_signature) IS NULL THEN
+    RAISE EXCEPTION 'Missing function % after grant changes', function_signature;
+  END IF;
+
+  IF has_function_privilege('anon', function_signature, 'EXECUTE') THEN
+    RAISE EXCEPTION 'anon still has EXECUTE on %', function_signature;
+  END IF;
+
+  IF has_function_privilege('authenticated', function_signature, 'EXECUTE') THEN
+    RAISE EXCEPTION 'authenticated still has EXECUTE on %', function_signature;
+  END IF;
+
+  IF NOT has_function_privilege('service_role', function_signature, 'EXECUTE') THEN
+    RAISE EXCEPTION 'service_role lacks EXECUTE on %', function_signature;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- Phase 2 unsubscribe hardening: `REVOKE` `update_user_preferences` from `PUBLIC` / `anon` / `authenticated`, `GRANT EXECUTE` to `service_role` only.
- Docs updated to mark Phase 2 as current after live Phase 1 smoke.

## Test plan
- [ ] After migration applies: confirm unsubscribe link still works (EF uses service_role)
- [ ] Confirm anon/authenticated cannot `rpc(update_user_preferences, ...)` from browser
- [ ] Settings email toggle still updates via direct `profiles` update (not this RPC)
