### PR TITLE
chore(unsubscribe): stop returning PII in EF response

### DIFF
--- a/docs/superpowers/specs/2026-07-15-secure-unsubscribe-flow-design.md
+++ b/docs/superpowers/specs/2026-07-15-secure-unsubscribe-flow-design.md
@@ -1,7 +1,7 @@
 # Secure Unsubscribe Flow Design
 
 Date: 2026-07-15  
-Status: Phase 1 live; Phase 2 grants lockdown implemented
+Status: Complete (Phase 1 + Phase 2 + response PII cleanup)
 
 ## Problem
 
@@ -27,6 +27,10 @@ Browser never chooses `user_id`. One Edge Function verifies the JWT and applies 
 Migration: `REVOKE` `update_user_preferences` from `PUBLIC` / `anon` / `authenticated`; `GRANT` to `service_role` only.
 
 Optional later cleanup: stop returning `userId` / `email` in the Edge Function JSON (kept for transitional clients).
+
+### Response cleanup — done
+
+Success response is `{ success: true, type }` only — no `userId` / `email` echoed to the browser.
 
 ## Token / type semantics
 

--- a/llm-instructions/features/email/email-unsubscribe-system-guide.md
+++ b/llm-instructions/features/email/email-unsubscribe-system-guide.md
@@ -98,7 +98,7 @@ interface UnsubscribeTokenPayload {
 2. **אימות Token**: בדיקת חתימה HMAC ותפוגה
 3. **קביעת סוג**: מעדיפים את `type` החתום ב־JWT; `body.type` רק כ־fallback
 4. **עדכון העדפות**: RPC `update_user_preferences` דרך service_role
-5. **תגובה**: JSON `{ success, type, payload }` — הדף מציג הצלחה/שגיאה ב־UI
+5. **תגובה**: JSON `{ success, type }` — בלי `userId`/`email` בדפדפן; הדף מציג הצלחה/שגיאה ב־UI
 
 #### 3.3 דף התגובה (Frontend)
 

--- a/supabase/functions/verify-unsubscribe-token/index.ts
+++ b/supabase/functions/verify-unsubscribe-token/index.ts
@@ -125,12 +125,6 @@ serve(async (req) => {
       JSON.stringify({
         success: true,
         type: unsubscribeType,
-        payload: {
-          userId: payload.userId,
-          email: payload.email,
-          type: unsubscribeType,
-          exp: payload.exp,
-        },
       }),
       {
         headers: {


### PR DESCRIPTION
## Summary
- `verify-unsubscribe-token` success response is now `{ success, type }` only (no `userId` / `email`).
- Frontend already used only `success` / `type` / `error` — no page changes needed.
- Docs updated; closes the optional Phase 2 cleanup.

## Test plan
- [ ] After EF deploy succeeds: open an unsubscribe link → success UI still works
- [ ] Network response has no `userId` / `email` / `payload`
- [ ] Invalid token still returns error JSON
