### PR TITLE
fix(db): move remaining cron jobs to Vault secrets

### DIFF
--- a/llm-instructions/features/email/email-reminders-feature-complete-guide.md
+++ b/llm-instructions/features/email/email-reminders-feature-complete-guide.md
@@ -497,32 +497,36 @@ curl -X POST "https://flpzqbvbymoluoeeeofg.supabase.co/functions/v1/send-reminde
 ### Cron Job Setup
 
 **Status**: ✅ **IMPLEMENTED AND ACTIVE**
-**Schedule**: Daily execution at 18:00 UTC (20:00 Israel time)
+**Schedule**: Daily execution at 18:00 UTC (21:00 Israel time)
 **Trigger**: Supabase scheduled function via pg_cron extension
+**Auth**: Vault secrets `functions_base_url` + `service_role_key` (no hardcoded JWT)
 
 ```sql
--- Active cron job setup
+-- Active pattern (see migration 20260716100000_cron_jobs_use_vault_secrets.sql)
 SELECT cron.schedule(
   'send-reminder-emails',
-  '0 18 * * *', -- Daily at 18:00 UTC (20:00 Israel time)
-  'SELECT net.http_post(
-    url:=''https://flpzqbvbymoluoeeeofg.supabase.co/functions/v1/send-reminder-emails'',
-    headers:=''{"Authorization": "Bearer YOUR_ANON_KEY"}'',
-    body:=''{}''
-  );'
+  '0 18 * * *', -- Daily at 18:00 UTC (21:00 Israel)
+  $$
+    SELECT net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/send-reminder-emails',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      ),
+      body := '{}'::jsonb
+    );
+  $$
 );
 ```
 
 **Job Details**:
 
-- **Job ID**: 3
 - **Status**: Active
 - **Schedule**: `0 18 * * *` (18:00 UTC daily)
 - **Local Times**:
-  - 🇮🇱 Israel: 20:00 (8 PM)
-  - 🇺🇸 New York: 13:00 (1 PM)
-  - 🇬🇧 London: 18:00 (6 PM)
-  - 🇦🇺 Sydney: 05:00+1 (5 AM next day)
+  - 🇮🇱 Israel: 21:00 (9 PM)
+  - 🇺🇸 New York: 14:00 (2 PM) / 13:00 when EST
+  - 🇬🇧 London: 19:00 (7 PM) / 18:00 when GMT
 
 **Monitoring**:
 

--- a/llm-instructions/features/email/email-reminders-feature-complete-guide.md
+++ b/llm-instructions/features/email/email-reminders-feature-complete-guide.md
@@ -497,7 +497,7 @@ curl -X POST "https://flpzqbvbymoluoeeeofg.supabase.co/functions/v1/send-reminde
 ### Cron Job Setup
 
 **Status**: ✅ **IMPLEMENTED AND ACTIVE**
-**Schedule**: Daily execution at 18:00 UTC (21:00 Israel time)
+**Schedule**: Daily execution at 18:00 UTC (20:00 Israel in winter / 21:00 in summer)
 **Trigger**: Supabase scheduled function via pg_cron extension
 **Auth**: Vault secrets `functions_base_url` + `service_role_key` (no hardcoded JWT)
 
@@ -505,7 +505,7 @@ curl -X POST "https://flpzqbvbymoluoeeeofg.supabase.co/functions/v1/send-reminde
 -- Active pattern (see migration 20260716100000_cron_jobs_use_vault_secrets.sql)
 SELECT cron.schedule(
   'send-reminder-emails',
-  '0 18 * * *', -- Daily at 18:00 UTC (21:00 Israel)
+  '0 18 * * *', -- Daily at 18:00 UTC (20:00 Israel in winter / 21:00 in summer)
   $$
     SELECT net.http_post(
       url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/send-reminder-emails',
@@ -524,7 +524,7 @@ SELECT cron.schedule(
 - **Status**: Active
 - **Schedule**: `0 18 * * *` (18:00 UTC daily)
 - **Local Times**:
-  - 🇮🇱 Israel: 21:00 (9 PM)
+  - 🇮🇱 Israel: 20:00 (8 PM) in winter / 21:00 (9 PM) in summer
   - 🇺🇸 New York: 14:00 (2 PM) / 13:00 when EST
   - 🇬🇧 London: 19:00 (7 PM) / 18:00 when GMT
 

--- a/supabase/MIGRATION_VAULT_SETUP.md
+++ b/supabase/MIGRATION_VAULT_SETUP.md
@@ -36,6 +36,9 @@ The `service_role` JWT used to authenticate cron job requests to Edge Functions.
 | Job name | Secrets used |
 |----------|-------------|
 | `daily-recurring-executor` | `functions_base_url`, `service_role_key` |
+| `send-reminder-emails` | `functions_base_url`, `service_role_key` |
+| `send-new-user-email-daily` | `functions_base_url`, `service_role_key` |
+| `monitor-cron-failures` | `functions_base_url`, `service_role_key` |
 
 ---
 

--- a/supabase/migrations/20260716100000_cron_jobs_use_vault_secrets.sql
+++ b/supabase/migrations/20260716100000_cron_jobs_use_vault_secrets.sql
@@ -1,0 +1,71 @@
+-- Move remaining cron jobs off hardcoded URL + service_role JWT.
+-- Match daily-recurring-executor: Vault secrets functions_base_url + service_role_key.
+--
+-- PREREQUISITE: Both secrets must exist in Supabase Vault (see supabase/MIGRATION_VAULT_SETUP.md).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'functions_base_url'
+  ) THEN
+    RAISE EXCEPTION
+      'Missing vault secret functions_base_url. See supabase/MIGRATION_VAULT_SETUP.md';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'service_role_key'
+  ) THEN
+    RAISE EXCEPTION
+      'Missing vault secret service_role_key. See supabase/MIGRATION_VAULT_SETUP.md';
+  END IF;
+END;
+$$;
+
+SELECT cron.unschedule('send-reminder-emails');
+SELECT cron.schedule(
+  'send-reminder-emails',
+  '0 18 * * *',
+  $$
+    SELECT net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/send-reminder-emails',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      ),
+      body := '{}'::jsonb
+    );
+  $$
+);
+
+SELECT cron.unschedule('send-new-user-email-daily');
+SELECT cron.schedule(
+  'send-new-user-email-daily',
+  '0 19 * * *',
+  $$
+    SELECT net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/send-new-user-email',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      ),
+      body := '{}'::jsonb
+    );
+  $$
+);
+
+SELECT cron.unschedule('monitor-cron-failures');
+SELECT cron.schedule(
+  'monitor-cron-failures',
+  '0 7 * * *',
+  $$
+    SELECT net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/send-cron-alerts',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      ),
+      body := '{}'::jsonb,
+      timeout_milliseconds := 1000
+    );
+  $$
+);

--- a/supabase/migrations/20260716100000_cron_jobs_use_vault_secrets.sql
+++ b/supabase/migrations/20260716100000_cron_jobs_use_vault_secrets.sql
@@ -65,7 +65,7 @@ SELECT cron.schedule(
         'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
       ),
       body := '{}'::jsonb,
-      timeout_milliseconds := 1000
+      timeout_milliseconds := 30000
     );
   $$
 );

--- a/supabase/migrations/20260716110000_raise_monitor_cron_failures_timeout.sql
+++ b/supabase/migrations/20260716110000_raise_monitor_cron_failures_timeout.sql
@@ -1,0 +1,20 @@
+-- Raise monitor-cron-failures net.http_post timeout.
+-- 1000ms is too short for send-cron-alerts (DB queries + email).
+-- Applies to environments that already ran 20260716100000 with timeout 1000.
+
+SELECT cron.unschedule('monitor-cron-failures');
+SELECT cron.schedule(
+  'monitor-cron-failures',
+  '0 7 * * *',
+  $$
+    SELECT net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'functions_base_url' LIMIT 1) || '/functions/v1/send-cron-alerts',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1)
+      ),
+      body := '{}'::jsonb,
+      timeout_milliseconds := 30000
+    );
+  $$
+);


### PR DESCRIPTION
## Summary
- Reschedule `send-reminder-emails`, `send-new-user-email-daily`, and `monitor-cron-failures` to use Vault `functions_base_url` + `service_role_key` (same pattern as `daily-recurring-executor`).
- Migration fails fast if either Vault secret is missing.
- Docs updated in `MIGRATION_VAULT_SETUP.md` and email reminders guide.

## Test plan
- [ ] After migration applies: `SELECT jobname, command FROM cron.job` for the three jobs — no `eyJ`, commands reference Vault
- [ ] Confirm all four cron jobs still listed and active
- [ ] Optional: wait for next scheduled run or invoke Edge Functions manually
