### PR TITLE
fix(email): show new-user summary times in Israel TZ

### DIFF
--- a/llm-instructions/backend/supabase-integration-status.md
+++ b/llm-instructions/backend/supabase-integration-status.md
@@ -55,7 +55,7 @@ This document tracks the progress of integrating Supabase into the Ten10 project
 
 - **Edge Function:** `send-new-user-email` sends a daily summary (table + text) of new users only (filtered by `auth.users.created_at`).
 - **Data Source:** Uses Auth Admin API (`auth.admin.listUsers`) with a default 24h window; fetches matching `profiles` for `full_name`, `avatar_url`, `mailing_list_consent`, `reminder_enabled/day`.
-- **Email Format:** Table includes Avatar/Name/Email/User ID + Date (DD/MM/YYYY) + Time (HH:MM) + Mailing consent; text body mirrors the same info. If no new users are found, returns 200 with `sent:false` and does not send an email.
+- **Email Format:** Table includes Avatar/Name/Email/User ID + Date (DD/MM/YYYY) + Time (HH:MM, `Asia/Jerusalem`) + Mailing consent; text body mirrors the same info. If no new users are found, returns 200 with `sent:false` and does not send an email.
 - **Sender/SES:** Uses `SES_FROM_USERS` (recommended) and falls back to `users-update@ten10-app.com` by default (SES verified). This sender is intentionally isolated from the global `SES_FROM` used by reminder emails. Requires `AWS_ACCESS_KEY_ID/SECRET/REGION`.
 - **Security:** Function uses Service Role Key; the cron job must use a Service Role Bearer, not anon.
 - **Cron:** Daily pg_cron at `0 19 * * *` (21:00 Israel) via `net.http_post` to `/functions/v1/send-new-user-email` with Service Role authorization.

--- a/supabase/functions/send-new-user-email/index.ts
+++ b/supabase/functions/send-new-user-email/index.ts
@@ -71,6 +71,8 @@ const escapeHtml = (value: string) =>
 const formatBoolean = (value: boolean | null | undefined) =>
   value === true ? "Yes" : value === false ? "No" : "Unknown";
 
+const ISRAEL_TZ = "Asia/Jerusalem";
+
 const formatDateParts = (value: string | null | undefined) => {
   if (!value) {
     return { date: "Unknown", time: "Unknown" };
@@ -79,13 +81,20 @@ const formatDateParts = (value: string | null | undefined) => {
   if (isNaN(d.getTime())) {
     return { date: value, time: value };
   }
-  const toLocal = new Date(d.getTime());
-  const y = toLocal.getUTCFullYear();
-  const m = String(toLocal.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(toLocal.getUTCDate()).padStart(2, "0");
-  const hh = String(toLocal.getUTCHours()).padStart(2, "0");
-  const mm = String(toLocal.getUTCMinutes()).padStart(2, "0");
-  return { date: `${day}/${m}/${y}`, time: `${hh}:${mm}` };
+  // Display times in Israel local time (handles DST), not UTC.
+  const date = new Intl.DateTimeFormat("en-GB", {
+    timeZone: ISRAEL_TZ,
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(d);
+  const time = new Intl.DateTimeFormat("en-GB", {
+    timeZone: ISRAEL_TZ,
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(d);
+  return { date, time };
 };
 
 const fetchAuthUser = async (


### PR DESCRIPTION
## Summary
- `send-new-user-email` formats date/time with `Asia/Jerusalem` (DST-aware) instead of UTC `getUTC*` helpers.
- Docs note updated in `supabase-integration-status.md`.

## Test plan
- [ ] After EF deploy: invoke `send-new-user-email` and confirm download/user times match Israel local time
- [ ] Spot-check a known `created_at` UTC timestamp vs displayed HH:MM
