### PR TITLE
docs(email): sync llm-instructions with deployed design system

### DIFF
--- a/llm-instructions/backend/supabase-integration-status.md
+++ b/llm-instructions/backend/supabase-integration-status.md
@@ -53,42 +53,47 @@ This document tracks the progress of integrating Supabase into the Ten10 project
 
 ### Email Notifications - Reminder Emails (Monthly)
 
-- **Production:** The legacy reminder pipeline is operational; daily pg_cron
-  invokes the currently deployed function at `0 18 * * *`.
-- **Localized redesign status:** Implemented and locally verified on this
-  branch, but not yet deployed.
-- **Safe pending handoff order:** Deploy the static blur asset, apply the
-  expanded recipient RPC migration, verify its return shape and privileges,
-  deploy `send-reminder-emails`, then complete controlled sends and
-  Gmail/Outlook/Apple Mail verification.
-- **Editorial Go/No-Go:** Product approver **pending**; rabbinic approver
-  **pending**; approval date **pending**. Production rollout is **forbidden
-  until both approve all 24 localized encouragement items**.
-- **Readiness:** Migration shape/privilege verification and Gmail, Outlook, and
-  Apple Mail checks remain **pending**. Local automated checks alone do not
-  establish staging acceptance or production readiness.
-- **Branch implementation:** `email-copy.ts` provides Hebrew/English copy;
-  `email-templates.ts` adds localized subject, HTML, and plain text,
-  first-name greeting, monthly encouragement, and dynamic RTL/LTR;
-  `simple-email-service.ts` handles delivery.
-- **Branch localization source:** The expanded RPC reads
-  `profiles.client_preferences.language`, defaults to Hebrew, returns
-  `full_name`, and rotates 12 encouragement items by the current month in
-  `Asia/Jerusalem`.
-- **Existing scheduling:** The production cron and reminder-day/Shabbat
-  scheduling behavior are operational; only localization/redesign deployment
-  is pending.
+- **Production:** Deployed on `main` (PR #347). Daily pg_cron at `0 18 * * *`
+  invokes `send-reminder-emails` via Vault (`functions_base_url` +
+  `service_role_key`).
+- **Localized redesign:** Live. Hebrew/English copy, RTL/LTR, first-name
+  greeting, 12 monthly encouragements (`Asia/Jerusalem`), dynamic
+  `default_currency`, user email shell + shared tokens.
+- **RPC:** `get_reminder_users_with_emails` returns `language` (from
+  `client_preferences.language`, Hebrew fallback), `full_name`, and
+  `default_currency` (ILS fallback).
+- **Shared design:** User/admin shells in
+  `supabase/functions/_shared/email-layout-*.ts` + `email-tokens.ts`
+  (see reminders guide). Legacy `_shared/email-design.ts` is unused.
+- **Static asset:** `https://ten10-app.com/email/reminder-header-blur.png`
+  (cream gradient fallback when images are blocked).
+- **Still manual / pending:** Controlled client checks (Gmail / Outlook /
+  Apple Mail); Auth Dashboard templates from
+  `supabase/auth-email-templates.md` (not CI-deployed); editorial review of
+  the 24 encouragement strings if product still requires a formal sign-off.
 - **Security:** Test mode (`{"test": true}`) is service-role only; cron uses
   Vault `service_role_key`.
 
 ### Email Notifications - New Users Summary (Daily)
 
-- **Edge Function:** `send-new-user-email` sends a daily summary (table + text) of new users only (filtered by `auth.users.created_at`).
-- **Data Source:** Uses Auth Admin API (`auth.admin.listUsers`) with a default 24h window; fetches matching `profiles` for `full_name`, `avatar_url`, `mailing_list_consent`, `reminder_enabled/day`.
-- **Email Format:** Table includes Avatar/Name/Email/User ID + Date (DD/MM/YYYY) + Time (HH:MM, `Asia/Jerusalem`) + Mailing consent; text body mirrors the same info. If no new users are found, returns 200 with `sent:false` and does not send an email.
-- **Sender/SES:** Uses `SES_FROM_USERS` (recommended) and falls back to `users-update@ten10-app.com` by default (SES verified). This sender is intentionally isolated from the global `SES_FROM` used by reminder emails. Requires `AWS_ACCESS_KEY_ID/SECRET/REGION`.
-- **Security:** Function uses Service Role Key; the cron job must use a Service Role Bearer, not anon.
-- **Cron:** Daily pg_cron at `0 19 * * *` (21:00 Israel) via `net.http_post` to `/functions/v1/send-new-user-email` with Service Role authorization.
+- **Edge Function:** `send-new-user-email` sends an admin daily product summary
+  (new users + download requests + reminder-run metrics) via the **admin**
+  email shell (`Ten10 Operations`).
+- **Data Source:** Auth Admin API (`auth.admin.listUsers`) with a default 24h
+  window; matching `profiles`; download_requests; reminder_run_logs; optional
+  GitHub download snapshot.
+- **Email Format:** Admin chrome (800px, gold accent bar). User table includes
+  Avatar/Name/Email/User ID + Date (DD/MM/YYYY) + Time (HH:MM,
+  `Asia/Jerusalem`) + Mailing consent. Skips send (200 `sent:false`) when the
+  window has neither new profiles nor download requests.
+- **Recipient:** `NEW_USERS_SUMMARY_TO` or default `dev@ten10-app.com`.
+- **Sender/SES:** Uses `SES_FROM_USERS` (recommended) and falls back to
+  `users-update@ten10-app.com` by default (SES verified). Isolated from
+  reminder `SES_FROM`. Requires `AWS_ACCESS_KEY_ID/SECRET/REGION`.
+- **Security:** Function uses Service Role Key; the cron job must use a
+  Service Role Bearer, not anon.
+- **Cron:** Daily pg_cron at `0 19 * * *` (21:00 Israel) via `net.http_post`
+  to `/functions/v1/send-new-user-email` with Service Role authorization.
 
 ### Email Notifications - Desktop Download Requests (Email Routing)
 

--- a/llm-instructions/features/contact-us-feature.md
+++ b/llm-instructions/features/contact-us-feature.md
@@ -216,7 +216,8 @@ CREATE TABLE contact_messages (
 - **Process**:
   1. Receives webhook payload with inserted record
   2. Generates signed URLs for attachments (7-day validity)
-  3. Formats HTML email using the shared **Email Design System** (`_shared/email-design.ts`)
+  3. Formats HTML via `send-contact-email/email-template.ts` using the shared
+     **admin email shell** (`_shared/email-layout-admin.ts` + `email-tokens.ts`)
   4. Supports localized templates (Hebrew/RTL for Rabbi, English/LTR for Dev) with explicit styling for correct rendering
   5. Sends email via AWS SES using `SimpleEmailService` class
   6. Includes Reply-To header with user's email

--- a/llm-instructions/features/email/email-reminders-feature-complete-guide.md
+++ b/llm-instructions/features/email/email-reminders-feature-complete-guide.md
@@ -250,27 +250,46 @@ supabase/functions/send-reminder-emails/
 └── jwt-utils.ts             # Unsubscribe JWT URL generation
 ```
 
-**Shared utilities** (other email functions):
+**Shared email design system** (all transactional / ops emails):
 
 ```
 supabase/functions/
 ├── _shared/
-│   ├── cors.ts               # CORS headers utility
-│   └── email-design.ts       # Shared design system (contact/new-user emails)
-├── send-contact-email/
-├── send-new-user-email/
+│   ├── email-tokens.ts            # Colors, fonts, widths, header gradients, logo URL
+│   ├── email-layout-user.ts       # Warm cream user shell (600px) — reminders, download
+│   ├── email-layout-admin.ts      # Compact ops shell (800px, gold bar) — contact, daily summary, cron
+│   ├── email-admin-primitives.ts  # Badges, table th/td, gold accent callout
+│   ├── escape-html.ts             # Shared HTML escaping
+│   ├── simple-email-service.ts    # AWS SES helper (also used outside reminders)
+│   └── email-design.ts            # LEGACY unused — do not import; superseded by tokens/layouts
+├── send-contact-email/            # Admin shell
+├── send-new-user-email/           # Admin shell (daily product summary)
+├── send-cron-alerts/              # Admin shell
+├── process-email-request/         # User shell (download link)
 └── verify-captcha/
 ```
 
+**Local previews:** from repo root,
+`WRITE_EMAIL_PREVIEWS=1 npm test -- supabase/functions/_tests/email-previews.test.ts`
+writes HTML under `tmp/email-previews/` (gitignored). Serve that folder locally to inspect.
+
+**Auth templates (manual):** copy HTML/subjects from
+`supabase/auth-email-templates.md` into Supabase Dashboard → Authentication →
+Email Templates. Not deployed by CI.
+
 ### Localization Pipeline
 
-1. `get_reminder_users_with_emails` returns `language` from `client_preferences.language` (Hebrew fallback).
+1. `get_reminder_users_with_emails` returns `language` from
+   `client_preferences.language` (Hebrew fallback) and `default_currency`
+   (ILS fallback).
 2. `UserService` maps every RPC row, normalizes missing/invalid language to
    Hebrew and non-string `full_name` to `null`, then passes recipient data and
    tithe balances to `SimpleEmailService`.
 3. `email-copy.ts` provides locale-specific copy and 12 monthly encouragement entries.
 4. `getIsraelMonth()` selects the encouragement index using `Asia/Jerusalem`.
-5. `email-templates.ts` generates localized subject, HTML, and plain text.
+5. `email-templates.ts` generates localized subject, HTML, and plain text via
+   `renderUserEmailShell`, formats the balance with the user's currency, and
+   builds unsubscribe footer HTML.
 6. `extractFirstName(full_name)` adds an optional first-name greeting.
 7. `simple-email-service.ts` sends multipart MIME with `List-Unsubscribe` headers.
 

--- a/llm-instructions/features/email/email-system-future-improvements.md
+++ b/llm-instructions/features/email/email-system-future-improvements.md
@@ -4,42 +4,35 @@ This document tracks genuine follow-up work for reminder emails and the
 unsubscribe system. Completed foundations are retained only where they clarify
 the remaining backlog.
 
-## Implemented on Branch (Deployment Pending)
+## Deployed on Production (PR #347)
 
 - [x] Localized reminder subject, HTML, and plain-text bodies in Hebrew and
-  English (locally verified)
+  English
 - [x] Language selection from `profiles.client_preferences.language`, with
-  Hebrew fallback (locally verified)
-- [x] Dynamic RTL/LTR rendering (locally verified)
+  Hebrew fallback
+- [x] Dynamic RTL/LTR rendering
 - [x] Twelve monthly encouragement entries per locale, selected using the
-  current month in `Asia/Jerusalem` (locally verified)
-- [x] Optional first-name greeting from `full_name` (locally verified)
-- [x] Branded header asset with cream fallback (implemented locally)
-- [x] Basic responsive, table-based reminder template (implemented locally)
+  current month in `Asia/Jerusalem`
+- [x] Optional first-name greeting from `full_name`
+- [x] Branded header asset with cream fallback
+  (`/email/reminder-header-blur.png`)
+- [x] Shared user/admin email shells + tokens (`email-tokens`,
+  `email-layout-user`, `email-layout-admin`, `email-admin-primitives`)
+- [x] Dynamic tithe balance currency from `profiles.default_currency`
+- [x] Admin restyle for contact, daily summary, and cron alerts
 - [x] Signed unsubscribe links
 - [x] `List-Unsubscribe` and `List-Unsubscribe-Post` headers via SES Raw MIME
-
-The legacy reminder pipeline remains operational in production. The localized
-redesign items above are not production claims: the RPC migration, Edge
-Function deployment, static asset deployment, and manual email/client
-verification are still pending.
 
 No separate profile language column is planned. The existing
 `client_preferences.language` value is the source of truth.
 
-## Localized Reminder Go/No-Go Gate
+## Remaining Manual / Editorial
 
-- Product approver: **pending**
-- Rabbinic approver: **pending**
-- Approval date: **pending**
-- Production rollout is **forbidden until both approvers approve all 24
-  localized encouragement items**.
-
-The required safe order is: deploy the static header asset, apply the recipient
-RPC migration, verify its return shape and privileges, deploy the Edge
-Function, perform controlled sends, then consider production only after both
-editorial approvals. Migration privilege verification and Gmail, Outlook, and
-Apple Mail checks remain **pending**, so readiness remains conditional.
+- [ ] Controlled visual checks in Gmail, Outlook, Apple Mail (and image-blocked)
+- [ ] Copy Auth templates from `supabase/auth-email-templates.md` into the
+  Supabase Dashboard (not CI-deployed)
+- [ ] Formal product/rabbinic sign-off on the 24 encouragement strings, if
+  still required by process (code is already live)
 
 ## Design and User Experience
 
@@ -52,7 +45,6 @@ Apple Mail checks remain **pending**, so readiness remains conditional.
 
 ### Unsubscribe Pages
 
-- [ ] Improve brand alignment and responsive layout
 - [ ] Offer preference changes or reduced frequency before full unsubscribe
 - [ ] Add an optional cancellation feedback form
 - [ ] Improve success and error messages
@@ -102,18 +94,19 @@ Apple Mail checks remain **pending**, so readiness remains conditional.
 
 ## Broader Email Localization
 
-- [ ] Localize other transactional emails, including contact and new-user
-  summary emails
-- [ ] Reuse the reminder copy approach where appropriate without coupling Edge
-  Functions to frontend translation hooks
+- [x] Shared admin/user design system applied to contact, daily summary, cron,
+  and download emails (English ops copy for admin; contact already HE/EN by
+  channel)
+- [ ] Further localize remaining admin/ops copy where product wants Hebrew
 - [ ] Keep sender-specific templates and environment variables isolated
 
 ## Testing
 
 ### Automated
 
+- [x] Shared layout/token contracts + reminder/contact/cron/download/daily
+  summary template tests and local HTML preview harness
 - [ ] Expand unit coverage for JWT creation and verification
-- [ ] Expand template tests for escaping, locale direction, and fallbacks
 - [ ] Add integration coverage for recipient RPC, MIME generation, and
   unsubscribe behavior
 


### PR DESCRIPTION
## Summary
- Update integration status: localized reminders + shared shells are live on main (PR #347)
- Document shared tokens/layouts/primitives; mark `email-design.ts` as legacy unused
- Align contact-us and future-improvements docs with admin/user shells and remaining manual checks (Auth Dashboard, client QA)

## Test plan
- [x] Docs-only diff; no code/runtime changes
- [x] Spot-check links to `email-tokens`, layouts, `auth-email-templates.md`, preview harness

Made with [Cursor](https://cursor.com)