### PR TITLE
fix(db): harden RPC grants and RLS initplan

### DIFF
--- a/supabase/migrations/20260717120000_harden_security_definer_execute_grants.sql
+++ b/supabase/migrations/20260717120000_harden_security_definer_execute_grants.sql
@@ -1,0 +1,200 @@
+-- Harden SECURITY DEFINER RPC EXECUTE grants.
+-- A1: increment_download_count -> service_role only
+-- A2: admin RPCs -> authenticated (+ service_role), not anon
+-- A2b: trigger/event helpers -> no REST execute for app roles
+-- A3: analytics/user/contact RPCs -> authenticated (+ service_role), not anon
+
+DO $preconditions$
+DECLARE
+  required_signature text;
+  required_signatures constant text[] := ARRAY[
+    'public.increment_download_count(text)',
+    'public.get_admin_dashboard_stats()',
+    'public.get_admin_dashboard_stats(integer)',
+    'public.get_admin_monthly_trends(date,date)',
+    'public.get_earliest_system_date()',
+    'public.is_admin_user()',
+    'public.handle_new_user()',
+    'public.handle_updated_at()',
+    'public.rls_auto_enable()',
+    'public.get_analytics_breakdowns(text,text)',
+    'public.get_analytics_range_stats(text,text)',
+    'public.get_category_breakdown(text,text,text)',
+    'public.get_daily_transaction_heatmap(text,text,text)',
+    'public.get_user_categories(text)',
+    'public.get_user_payment_methods()',
+    'public.handle_contact_form(text,text,text,text,jsonb,text,text,text,text)',
+    'public.handle_contact_form(text,text,text,text,jsonb,text,text,text,text,text,text,text,text)'
+  ];
+BEGIN
+  FOREACH required_signature IN ARRAY required_signatures LOOP
+    IF to_regprocedure(required_signature) IS NULL THEN
+      RAISE EXCEPTION 'Required function is missing: %', required_signature;
+    END IF;
+  END LOOP;
+END;
+$preconditions$;
+
+-- ---------------------------------------------------------------------------
+-- A1: download rate-limit RPC (Edge Function uses service_role)
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.increment_download_count(text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.increment_download_count(text)
+  TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- A2: admin RPCs
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.get_admin_dashboard_stats()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_admin_dashboard_stats()
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_admin_dashboard_stats(integer)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_admin_dashboard_stats(integer)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_admin_monthly_trends(date, date)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_admin_monthly_trends(date, date)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_earliest_system_date()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_earliest_system_date()
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.is_admin_user()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.is_admin_user()
+  TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- A2b: trigger / event helpers (not callable via PostgREST)
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.handle_new_user()
+  FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.handle_updated_at()
+  FROM PUBLIC, anon, authenticated;
+
+REVOKE ALL ON FUNCTION public.rls_auto_enable()
+  FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------------
+-- A3: analytics / user helpers / contact
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON FUNCTION public.get_analytics_breakdowns(text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_analytics_breakdowns(text, text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_analytics_range_stats(text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_analytics_range_stats(text, text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_category_breakdown(text, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_category_breakdown(text, text, text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_daily_transaction_heatmap(text, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_daily_transaction_heatmap(text, text, text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_user_categories(text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_categories(text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.get_user_payment_methods()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_user_payment_methods()
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.handle_contact_form(
+  text, text, text, text, jsonb, text, text, text, text
+)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_contact_form(
+  text, text, text, text, jsonb, text, text, text, text
+)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.handle_contact_form(
+  text, text, text, text, jsonb, text, text, text, text, text, text, text, text
+)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_contact_form(
+  text, text, text, text, jsonb, text, text, text, text, text, text, text, text
+)
+  TO authenticated, service_role;
+
+-- ---------------------------------------------------------------------------
+-- Post-asserts
+-- ---------------------------------------------------------------------------
+DO $asserts$
+DECLARE
+  sig text;
+  service_only constant text[] := ARRAY[
+    'public.increment_download_count(text)'
+  ];
+  authenticated_ok constant text[] := ARRAY[
+    'public.get_admin_dashboard_stats()',
+    'public.get_admin_dashboard_stats(integer)',
+    'public.get_admin_monthly_trends(date,date)',
+    'public.get_earliest_system_date()',
+    'public.is_admin_user()',
+    'public.get_analytics_breakdowns(text,text)',
+    'public.get_analytics_range_stats(text,text)',
+    'public.get_category_breakdown(text,text,text)',
+    'public.get_daily_transaction_heatmap(text,text,text)',
+    'public.get_user_categories(text)',
+    'public.get_user_payment_methods()',
+    'public.handle_contact_form(text,text,text,text,jsonb,text,text,text,text)',
+    'public.handle_contact_form(text,text,text,text,jsonb,text,text,text,text,text,text,text,text)'
+  ];
+  trigger_locked constant text[] := ARRAY[
+    'public.handle_new_user()',
+    'public.handle_updated_at()',
+    'public.rls_auto_enable()'
+  ];
+BEGIN
+  FOREACH sig IN ARRAY service_only LOOP
+    IF has_function_privilege('anon', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'anon still has EXECUTE on %', sig;
+    END IF;
+    IF has_function_privilege('authenticated', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'authenticated still has EXECUTE on %', sig;
+    END IF;
+    IF NOT has_function_privilege('service_role', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'service_role lacks EXECUTE on %', sig;
+    END IF;
+  END LOOP;
+
+  FOREACH sig IN ARRAY authenticated_ok LOOP
+    IF has_function_privilege('anon', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'anon still has EXECUTE on %', sig;
+    END IF;
+    IF NOT has_function_privilege('authenticated', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'authenticated lacks EXECUTE on %', sig;
+    END IF;
+    IF NOT has_function_privilege('service_role', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'service_role lacks EXECUTE on %', sig;
+    END IF;
+  END LOOP;
+
+  FOREACH sig IN ARRAY trigger_locked LOOP
+    IF has_function_privilege('anon', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'anon still has EXECUTE on %', sig;
+    END IF;
+    IF has_function_privilege('authenticated', sig, 'EXECUTE') THEN
+      RAISE EXCEPTION 'authenticated still has EXECUTE on %', sig;
+    END IF;
+  END LOOP;
+END;
+$asserts$;

--- a/supabase/migrations/20260717120100_fix_rls_initplan_and_fk_indexes.sql
+++ b/supabase/migrations/20260717120100_fix_rls_initplan_and_fk_indexes.sql
@@ -1,0 +1,124 @@
+-- B1: wrap auth.* calls in RLS policies with (select ...) for initplan
+-- B2: covering indexes for hot foreign keys
+
+-- ---------------------------------------------------------------------------
+-- B1: admin_emails
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Admins can view admin_emails" ON public.admin_emails;
+CREATE POLICY "Admins can view admin_emails"
+  ON public.admin_emails
+  FOR SELECT
+  TO public
+  USING (
+    (SELECT auth.email()) IN (
+      SELECT admin_emails_1.email
+      FROM admin_emails admin_emails_1
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can insert admin_emails" ON public.admin_emails;
+CREATE POLICY "Admins can insert admin_emails"
+  ON public.admin_emails
+  FOR INSERT
+  TO public
+  WITH CHECK (
+    (SELECT auth.email()) IN (
+      SELECT admin_emails_1.email
+      FROM admin_emails admin_emails_1
+    )
+  );
+
+DROP POLICY IF EXISTS "Admins can delete admin_emails" ON public.admin_emails;
+CREATE POLICY "Admins can delete admin_emails"
+  ON public.admin_emails
+  FOR DELETE
+  TO public
+  USING (
+    (SELECT auth.email()) IN (
+      SELECT admin_emails_1.email
+      FROM admin_emails admin_emails_1
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- B1: download_rate_limits / download_requests
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Service role only" ON public.download_rate_limits;
+CREATE POLICY "Service role only"
+  ON public.download_rate_limits
+  FOR ALL
+  TO public
+  USING ((SELECT auth.role()) = 'service_role')
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "Service role only" ON public.download_requests;
+CREATE POLICY "Service role only"
+  ON public.download_requests
+  FOR ALL
+  TO public
+  USING ((SELECT auth.role()) = 'service_role')
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+-- ---------------------------------------------------------------------------
+-- B2: FK covering indexes
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS idx_transactions_source_recurring_id
+  ON public.transactions (source_recurring_id);
+
+CREATE INDEX IF NOT EXISTS idx_recurring_transactions_user_id
+  ON public.recurring_transactions (user_id);
+
+-- ---------------------------------------------------------------------------
+-- Post-asserts
+-- ---------------------------------------------------------------------------
+DO $asserts$
+DECLARE
+  policy_def text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'idx_transactions_source_recurring_id'
+  ) THEN
+    RAISE EXCEPTION 'Missing index idx_transactions_source_recurring_id';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'idx_recurring_transactions_user_id'
+  ) THEN
+    RAISE EXCEPTION 'Missing index idx_recurring_transactions_user_id';
+  END IF;
+
+  SELECT qual INTO policy_def
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename = 'admin_emails'
+    AND policyname = 'Admins can view admin_emails';
+
+  IF policy_def IS NULL
+     OR (
+       position('(SELECT auth.email())' in policy_def) = 0
+       AND position('(select auth.email())' in policy_def) = 0
+     ) THEN
+    RAISE EXCEPTION 'admin_emails view policy missing (select auth.email()) wrapper';
+  END IF;
+
+  SELECT qual INTO policy_def
+  FROM pg_policies
+  WHERE schemaname = 'public'
+    AND tablename = 'download_rate_limits'
+    AND policyname = 'Service role only';
+
+  IF policy_def IS NULL
+     OR (
+       position('(SELECT auth.role())' in policy_def) = 0
+       AND position('(select auth.role())' in policy_def) = 0
+     ) THEN
+    RAISE EXCEPTION 'download_rate_limits policy missing (select auth.role()) wrapper';
+  END IF;
+END;
+$asserts$;

--- a/supabase/migrations/20260717120100_fix_rls_initplan_and_fk_indexes.sql
+++ b/supabase/migrations/20260717120100_fix_rls_initplan_and_fk_indexes.sql
@@ -93,6 +93,7 @@ BEGIN
     RAISE EXCEPTION 'Missing index idx_recurring_transactions_user_id';
   END IF;
 
+  -- pg_policies rewrites (SELECT auth.fn()) to ( SELECT auth.fn() AS ... )
   SELECT qual INTO policy_def
   FROM pg_policies
   WHERE schemaname = 'public'
@@ -100,11 +101,9 @@ BEGIN
     AND policyname = 'Admins can view admin_emails';
 
   IF policy_def IS NULL
-     OR (
-       position('(SELECT auth.email())' in policy_def) = 0
-       AND position('(select auth.email())' in policy_def) = 0
-     ) THEN
-    RAISE EXCEPTION 'admin_emails view policy missing (select auth.email()) wrapper';
+     OR position('SELECT auth.email()' in policy_def) = 0 THEN
+    RAISE EXCEPTION 'admin_emails view policy missing SELECT auth.email() wrapper: %',
+      policy_def;
   END IF;
 
   SELECT qual INTO policy_def
@@ -114,11 +113,9 @@ BEGIN
     AND policyname = 'Service role only';
 
   IF policy_def IS NULL
-     OR (
-       position('(SELECT auth.role())' in policy_def) = 0
-       AND position('(select auth.role())' in policy_def) = 0
-     ) THEN
-    RAISE EXCEPTION 'download_rate_limits policy missing (select auth.role()) wrapper';
+     OR position('SELECT auth.role()' in policy_def) = 0 THEN
+    RAISE EXCEPTION 'download_rate_limits policy missing SELECT auth.role() wrapper: %',
+      policy_def;
   END IF;
 END;
 $asserts$;


### PR DESCRIPTION
## Summary
- Revoke `anon` EXECUTE on admin/analytics/contact SECURITY DEFINER RPCs; lock `increment_download_count` to `service_role` only; lock trigger helpers off REST roles
- Rewrite RLS policies on `admin_emails` / download tables with `(select auth.*())` initplan pattern
- Add FK covering indexes on `transactions.source_recurring_id` and `recurring_transactions.user_id`

## Staging note
Staging MCP (`ngtsnskyupageagcmqdp`) timed out during apply (project may be paused). Function signatures were verified read-only against production. Opening this PR will run `Deploy Supabase Migrations` and push to production.

## Test plan
- [ ] Confirm GitHub Action `Deploy Supabase Migrations` succeeds on this PR
- [ ] Admin `/admin` loads for admin user; non-admin still redirected
- [ ] Analytics / categories / payment methods RPCs work while logged in
- [ ] Contact form submit (authenticated) succeeds
- [ ] Download email flow (`process-email-request`) still rate-limits via service role
- [ ] Re-check Supabase security/performance advisors after deploy
