### PR TITLE
docs(db): note staging project deleted

### DIFF
--- a/.cursor/rules/core-standards/RULE.md
+++ b/.cursor/rules/core-standards/RULE.md
@@ -20,8 +20,8 @@ alwaysApply: true
 
 When changing Supabase schema, RPC, cron, or permissions:
 
-1. **Staging first** – Apply via MCP (`project_id=ngtsnskyupageagcmqdp`) or Dashboard. Verify locally.
-2. **File in repo** – Create `supabase/migrations/YYYYMMDDHHMMSS_description.sql` before applying.
+1. **File in repo** – Create `supabase/migrations/YYYYMMDDHHMMSS_description.sql` before applying.
+2. **Staging is optional** – There is no always-on staging project (former `ngtsnskyupageagcmqdp` was deleted). Recreate staging only when needed; otherwise open a PR carefully (CI `db push` hits production on PR open).
 3. **Open PR** – GitHub Action runs `db push` on production (so you can test Vercel preview before merge).
 4. **Never** run ad-hoc SQL on production without a migration file in Git.
 

--- a/.cursor/rules/supabase-database-migrations.mdc
+++ b/.cursor/rules/supabase-database-migrations.mdc
@@ -10,14 +10,16 @@ alwaysApply: false
 
 | Environment | Project ID (MCP) | Role |
 |-------------|------------------|------|
-| Staging | `ngtsnskyupageagcmqdp` | Test migrations first |
-| Production | `flpzqbvbymoluoeeeofg` | Updated via merge to main |
+| Production | `flpzqbvbymoluoeeeofg` | Updated via PR / merge to main (GitHub Action `db push`) |
+| Staging | *none — deleted* | Recreate on demand if you need a pre-prod DB |
+
+**Staging note:** The former staging project (`ngtsnskyupageagcmqdp`) was deleted to avoid idle cost. Do not call that ref. If staging is needed, create a new Supabase project, update this rule + `llm-instructions/backend/supabase-database-migrations-workflow.md` with the new ref, push migrations, set Vault secrets, then test. See that workflow doc § “Recreate staging”.
 
 ## Workflow (always follow)
 
 1. Create migration file: `supabase/migrations/YYYYMMDDHHMMSS_description.sql` (full timestamp).
-2. Apply to staging: MCP `apply_migration(project_id=ngtsnskyupageagcmqdp, name, query)`.
-3. Verify: `.env` → staging, `npm run dev`, test.
+2. **If staging exists:** apply via MCP `apply_migration(project_id=<staging-ref>, name, query)`, verify with `.env` → staging.
+3. **If no staging (current default):** proceed with careful review; opening a PR pushes to **production** via CI.
 4. Open PR → GitHub Action pushes to **production** (Vercel preview works).
 5. Merge to main.
 
@@ -25,20 +27,10 @@ alwaysApply: false
 
 | MCP server | Connected to | Use for |
 |---|---|---|
-| `plugin-supabase-supabase` | requires `project_id` param | ✅ staging migrations |
-| `user-supabase` | **PRODUCTION** hardcoded | ❌ never for migrations |
+| `plugin-supabase-supabase` | requires `project_id` param | staging (only after recreate) |
+| `user-supabase` / `user-supabase ten10` | **PRODUCTION** | ❌ never for migrations |
 
-**CRITICAL**: `user-supabase` MCP is hardwired to production (`flpzqbvbymoluoeeeofg`).  
-**Always use `plugin-supabase-supabase` with `project_id: "ngtsnskyupageagcmqdp"` for staging.**
-
-### Correct apply_migration call:
-```
-plugin-supabase-supabase › apply_migration({
-  project_id: "ngtsnskyupageagcmqdp",
-  name: "description_snake_case",
-  query: "..."
-})
-```
+**CRITICAL**: Production MCP is hardwired to `flpzqbvbymoluoeeeofg`. Never use it to apply migrations.
 
 ### After apply_migration (fix auto-timestamp):
 MCP generates its own timestamp → mismatches the file. Fix:
@@ -52,7 +44,7 @@ VALUES ('20260423120000', 'migration_name', ARRAY['...']) ON CONFLICT DO NOTHING
 
 | Target | Command | Who triggers |
 |--------|---------|-------------|
-| Staging (test) | `npx supabase functions deploy <name> --project-ref ngtsnskyupageagcmqdp` | Agent / developer manually |
+| Staging (only if recreated) | `npx supabase functions deploy <name> --project-ref <new-staging-ref>` | Agent / developer manually |
 | Production | **Never manually** | GitHub Action on push to `main` |
 
 ⚠️ **`process-email-request` must always use `--no-verify-jwt`** — omitting it breaks Cloudflare email routing. The GitHub Action already handles this. Never redeploy it manually without the flag.
@@ -61,7 +53,8 @@ The GitHub Action (`deploy-supabase-functions.yml`) triggers on push to `main` w
 
 ## Do not
 
-- Use `user-supabase` MCP for any migration (it goes to production).
+- Use production MCP for any migration.
+- Assume staging ref `ngtsnskyupageagcmqdp` still exists.
 - Run ad-hoc SQL on production without a migration file in Git.
 - Edit or delete migration files already applied on production.
 - Run `supabase db reset` on production.

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Copy to .env and fill in real values. Never commit .env.
 
 # Supabase (web platform only — required for web dev/build)
+# Default: production (flpzqbvbymoluoeeeofg). There is no always-on staging project;
+# if you recreate staging, put that project's URL/keys here temporarily for local smoke tests.
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 

--- a/llm-instructions/backend/supabase-database-migrations-workflow.md
+++ b/llm-instructions/backend/supabase-database-migrations-workflow.md
@@ -4,9 +4,9 @@ This document describes the full process for applying database changes (schema, 
 
 ## Overview
 
-- **DEV**: Create migration file, push to staging via MCP, verify.
+- **DEV**: Create a versioned migration file in git.
 - **PR**: Opening a PR triggers GitHub Action → `db push` to **production** (so you can test Vercel preview before merge).
-- **Staging**: MCP only (manual). No double push – staging gets it once via MCP.
+- **Staging (optional):** There is **no always-on staging project**. The previous staging project was deleted to avoid idle compute cost. If you need a staging DB, recreate one first (see below), then apply there before opening the PR.
 - **Only new migrations**: Do not modify history, legacy files, or applied migrations.
 
 ---
@@ -15,8 +15,26 @@ This document describes the full process for applying database changes (schema, 
 
 | Environment | Project Ref | Use |
 |-------------|-------------|-----|
-| **Production** | `flpzqbvbymoluoeeeofg` | Live app – updated via GitHub Action on merge |
-| **Staging** | `ngtsnskyupageagcmqdp` | Test migrations before production |
+| **Production** | `flpzqbvbymoluoeeeofg` | Live app – updated via GitHub Action on PR / push to main |
+| **Staging** | *none (deleted)* | Recreate on demand when you need a safe pre-prod DB |
+
+### Staging status (important)
+
+- Former staging ref `ngtsnskyupageagcmqdp` is **gone** (project deleted).
+- Do **not** assume staging MCP / that project ref still works.
+- Default path today: write migration → open PR → production `db push` via CI → smoke on Vercel preview / production carefully.
+- Prefer low-risk migrations (grants, indexes, additive DDL). For destructive or hard-to-revert changes, recreate staging first.
+
+### Recreate staging (when needed)
+
+1. Create a new Supabase project (same region as prod if possible).
+2. Record the new project ref; update this doc, `.cursor/rules/supabase-database-migrations.mdc`, `.env` staging vars, and any staging MCP config.
+3. Link CLI / push schema history: `supabase db push` (or apply migrations) against the new project.
+4. Set Vault secrets (`functions_base_url`, `service_role_key`) for that project — see `supabase/MIGRATION_VAULT_SETUP.md`.
+5. Deploy needed Edge Functions to the new ref for smoke tests.
+6. Point local `.env` at staging URL/keys, run `npm run dev`, verify, then open the production PR as usual.
+
+Pause or delete staging again when finished if you want to avoid ongoing cost.
 
 ---
 
@@ -38,14 +56,13 @@ ADD COLUMN IF NOT EXISTS payment_notes TEXT;
 - Use snake_case: `add_payment_notes`, not `addPaymentNotes`
 - Never edit or delete migrations already applied on production
 
-### 2. Apply to staging
+### 2. Optional: apply to staging (only if a staging project exists)
+
+If you recreated staging, apply there first with MCP or Dashboard.
 
 **Option A – MCP (recommended from Cursor)**
 
-Use `plugin-supabase-supabase` with `project_id`:
-
-- Staging: `ngtsnskyupageagcmqdp`
-- Production: `flpzqbvbymoluoeeeofg`
+Use `plugin-supabase-supabase` with the **current** staging `project_id` (after recreate). Never use production MCP (`user-supabase` / `flpzqbvbymoluoeeeofg`) to apply migrations.
 
 ```
 apply_migration(project_id, name, query)  → Runs SQL + registers in schema_migrations
@@ -71,11 +88,10 @@ VALUES ('<file-timestamp>', '<file-timestamp>_<name>', ARRAY[]::text[]);
    ON CONFLICT (version) DO NOTHING;
    ```
 
-### 3. Verify on staging
+### 3. Verify
 
-- Point `.env` to staging (uncomment staging vars, comment production)
-- Run `npm run dev` and test the change
-- If the migration involves Edge Functions: deploy to staging (`npx supabase functions deploy <name> --project-ref ngtsnskyupageagcmqdp`)
+- With staging: point `.env` to staging, `npm run dev`, test.
+- Without staging: rely on careful review + Vercel preview after PR open (production already received `db push` from CI).
 
 ### 4. Open PR
 
@@ -99,6 +115,7 @@ Merge. Production already has the migration from step 4. Push to main triggers t
 - Do **not** edit or delete migration files already applied on production
 - Do **not** run `supabase db reset` on production
 - Do **not** run files under `supabase/migrations/rollback/` on production unless you know why
+- Do **not** call staging project ref `ngtsnskyupageagcmqdp` — it no longer exists
 
 ---
 
@@ -108,10 +125,10 @@ Some migrations (e.g. cron jobs) use `vault.decrypted_secrets`. Secrets must be 
 
 ### Required Vault Secrets
 
-| Name | Production | Staging |
-|------|-----------|---------|
-| `functions_base_url` | `https://flpzqbvbymoluoeeeofg.supabase.co` | `https://ngtsnskyupageagcmqdp.supabase.co` |
-| `service_role_key` | service_role JWT from Project Settings → API | service_role JWT from Project Settings → API |
+| Name | Production | Staging (if recreated) |
+|------|-----------|-------------------------|
+| `functions_base_url` | `https://flpzqbvbymoluoeeeofg.supabase.co` | `https://<new-staging-ref>.supabase.co` |
+| `service_role_key` | service_role JWT from Project Settings → API | service_role JWT from that project's API settings |
 
 ### How to Add
 
@@ -131,15 +148,15 @@ SELECT vault.create_secret('<value>', '<name>', '<description>');
 
 ---
 
-## Edge Functions and Staging
-
-Edge Functions are deployed per project. To test a function on staging:
-
-```bash
-npx supabase functions deploy <function-name> --project-ref ngtsnskyupageagcmqdp
-```
+## Edge Functions
 
 Production gets functions via GitHub Action (`deploy-supabase-functions.yml`) on push to `main` when `supabase/functions/**` changes.
+
+If you recreated staging and need to test a function there:
+
+```bash
+npx supabase functions deploy <function-name> --project-ref <new-staging-ref>
+```
 
 **CI allowlist:** `deploy-changed-functions.sh` only deploys names in `ALL_FUNCTIONS` (and redeploys `SHARED_DEPENDENT` when `_shared` changes). A new function that is not listed is skipped with a warning — CI can still be green while production returns **404** on that path (browsers often surface this as a CORS preflight failure). See `supabase-edge-functions-maintenance.md` §4.
 

--- a/llm-instructions/backend/supabase-integration-status.md
+++ b/llm-instructions/backend/supabase-integration-status.md
@@ -261,9 +261,9 @@ This document tracks the progress of integrating Supabase into the Ten10 project
 
 ### Database migrations workflow and Branching
 
-- **Workflow:** All schema/RPC/cron changes go into versioned migration files in `supabase/migrations/`. Apply to staging manually (MCP or Dashboard), verify, then open PR; GitHub Action `deploy-supabase-migrations.yml` runs `db push` on production when PR is opened (so you can test Vercel preview before merge). See `llm-instructions/backend/supabase-database-migrations-workflow.md`.
+- **Workflow:** All schema/RPC/cron changes go into versioned migration files in `supabase/migrations/`. Opening a PR runs GitHub Action `deploy-supabase-migrations.yml` → `db push` on production (Vercel preview before merge). Staging is **optional / on-demand** (former staging project deleted); recreate only when needed. See `llm-instructions/backend/supabase-database-migrations-workflow.md`.
 - **Recurring-transactions cron (pg_cron):** The daily job `daily-recurring-executor` calls the Edge Function `process-recurring-transactions`. Its base URL is read from Supabase Vault (secret name `functions_base_url`) so the same migration works on production and on Supabase branches. Migration: `20260225100000_cron_use_vault_for_functions_url.sql`. After applying that migration, create the Vault secret once per environment; see `supabase/MIGRATION_VAULT_SETUP.md` and `supabase/CRON_VAULT_APPLY_STEP_BY_STEP.md`.
-- **Branches and CI/CD:** Staging: apply migrations manually (MCP or Dashboard). Production: migrations via `deploy-supabase-migrations.yml` on **PR open** (and push to main); functions via `deploy-supabase-functions.yml` on push to `main`. See `llm-instructions/backend/supabase-database-migrations-workflow.md`.
+- **Branches and CI/CD:** Production migrations via `deploy-supabase-migrations.yml` on **PR open** (and push to main); functions via `deploy-supabase-functions.yml` on push to `main`. Staging is not always running — see migrations workflow for recreate steps.
 
 ### General
 

--- a/llm-instructions/utilities/migration-guide.md
+++ b/llm-instructions/utilities/migration-guide.md
@@ -217,8 +217,8 @@ When you (the user) request a schema change (e.g., "add a 'priority' field to tr
 
 For the **web (Supabase)** project:
 
-1. **Apply to staging first** – Use MCP (`plugin-supabase-supabase`, `project_id=ngtsnskyupageagcmqdp`) or Dashboard SQL Editor. Verify with `npm run dev` pointing to staging.
-2. **Create** the migration file in `supabase/migrations/` (e.g. `YYYYMMDDHHMMSS_description.sql`) and **commit to Git**.
+1. **Create** the migration file in `supabase/migrations/` (e.g. `YYYYMMDDHHMMSS_description.sql`) and **commit to Git**.
+2. **Staging (optional)** – There is no always-on staging project (former ref deleted). Recreate staging only when needed; see `supabase-database-migrations-workflow.md`.
 3. **Open PR** – GitHub Action `deploy-supabase-migrations.yml` runs `db push` on production (so you can test Vercel preview before merge).
 
 **References:** See **`llm-instructions/backend/supabase-database-migrations-workflow.md`** for the full step-by-step workflow, MCP usage, and staging/production flow.

--- a/supabase/MIGRATION_VAULT_SETUP.md
+++ b/supabase/MIGRATION_VAULT_SETUP.md
@@ -15,7 +15,7 @@ Base URL for calling Edge Functions from cron jobs.
 | Environment | Value |
 |-------------|-------|
 | Production  | `https://flpzqbvbymoluoeeeofg.supabase.co` |
-| Staging     | `https://ngtsnskyupageagcmqdp.supabase.co` |
+| Staging     | *No staging project right now.* If you recreate one, use `https://<new-staging-ref>.supabase.co` and update `llm-instructions/backend/supabase-database-migrations-workflow.md`. |
 
 ### `service_role_key`
 
@@ -24,7 +24,7 @@ The `service_role` JWT used to authenticate cron job requests to Edge Functions.
 | Environment | Value |
 |-------------|-------|
 | Production  | service_role JWT from Dashboard → Project Settings → API |
-| Staging     | service_role JWT from Dashboard → Project Settings → API |
+| Staging     | Only if staging is recreated: service_role JWT from that project's API settings |
 
 > **Security note:** This key bypasses Row Level Security. Never commit it to git.
 > Always add it via the Dashboard UI.


### PR DESCRIPTION
## Summary
- Document that Supabase staging was deleted (cost) and is optional/on-demand
- Update migration workflow, cursor rules, vault setup, and `.env.example`
- Default path: migration file → PR → production `db push` via CI

## Test plan
- [ ] Skim `llm-instructions/backend/supabase-database-migrations-workflow.md` for clarity
- [ ] Confirm agents/rules no longer assume `ngtsnskyupageagcmqdp` exists
