### PR TITLE
chore(deps): bump i18next + react-i18next together (#356, #360)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "react-dom": "^19.2.7",
         "react-dropzone": "^14.3.8",
         "react-hook-form": "^7.81.0",
-        "react-i18next": "^16.5.2",
+        "react-i18next": "^17.0.10",
         "react-resizable-panels": "^3.0.6",
         "react-turnstile": "^1.1.4",
         "recharts": "^3.9.2",
@@ -10118,9 +10118,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.6.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.10.tgz",
+      "integrity": "sha512-XneHftyYA774MJkkccSkZ5oKrUpCnXIPmxio3wemqrVzCRLWiGXOMbIzObrer03fNDEnm8g8R5yYls4HcE+esg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -10128,9 +10128,9 @@
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 25.10.9",
+        "i18next": ">= 26.2.0",
         "react": ">= 16.8.0",
-        "typescript": "^5 || ^6"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "react-dom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "exceljs": "^4.4.0",
         "framer-motion": "^12.42.2",
         "html-to-image": "^1.11.13",
-        "i18next": "^25.7.4",
+        "i18next": "^26.3.6",
         "i18next-browser-languagedetector": "^8.2.0",
         "i18next-http-backend": "^4.0.0",
         "input-otp": "^1.4.2",
@@ -8143,9 +8143,9 @@
       "license": "MIT"
     },
     "node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "version": "26.3.6",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.6.tgz",
+      "integrity": "sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==",
       "funding": [
         {
           "type": "individual",
@@ -8161,11 +8161,8 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
       "peerDependencies": {
-        "typescript": "^5 || ^6"
+        "typescript": "^5 || ^6 || ^7"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "exceljs": "^4.4.0",
     "framer-motion": "^12.42.2",
     "html-to-image": "^1.11.13",
-    "i18next": "^25.7.4",
+    "i18next": "^26.3.6",
     "i18next-browser-languagedetector": "^8.2.0",
     "i18next-http-backend": "^4.0.0",
     "input-otp": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-dom": "^19.2.7",
     "react-dropzone": "^14.3.8",
     "react-hook-form": "^7.81.0",
-    "react-i18next": "^16.5.2",
+    "react-i18next": "^17.0.10",
     "react-resizable-panels": "^3.0.6",
     "react-turnstile": "^1.1.4",
     "recharts": "^3.9.2",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merges Dependabot #356 and #360 together — `react-i18next@17` requires `i18next >= 26.2`, so these must land as one bump.

| Kept | What |
|---|---|
| #356 | `i18next` 25 → 26.3.6 |
| #360 | `react-i18next` 16 → 17.0.10 |

## Verification

- Cherry-picks clean on current `main`
- `tsc --noEmit` ✅
- `npm audit --omit=dev` ✅ (0 vulnerabilities)
- Full vitest: same pre-existing `email-previews.test.ts` failures as on `main` (unrelated)

## After merge

Close as superseded: #356, #360
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69ed7544-3feb-497d-ae86-05b9efb5cd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69ed7544-3feb-497d-ae86-05b9efb5cd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

