### PR TITLE
chore(deps): bump react-dropzone to v19 + reject feedback in contact upload

### DIFF
--- a/llm-instructions/features/contact-us-feature.md
+++ b/llm-instructions/features/contact-us-feature.md
@@ -113,6 +113,7 @@ This flow leverages Tauri's secure bridge between the frontend and the Rust back
 - **Features**:
   - Drag-and-drop or click to select
   - File validation (max 3 files, 5MB each by default)
+  - Rejection feedback via `toast.warning` (`onDropRejected`: too large / too many / unsupported type) — matches project toast guidelines; import wizard keeps an inline `Alert` instead because it is a dedicated step
   - Visual feedback for selected files with size display
   - File removal before submission
   - Full i18n support (all text comes from translation files)

--- a/llm-instructions/features/contact-us-feature.md
+++ b/llm-instructions/features/contact-us-feature.md
@@ -113,7 +113,7 @@ This flow leverages Tauri's secure bridge between the frontend and the Rust back
 - **Features**:
   - Drag-and-drop or click to select
   - File validation (max 3 files, 5MB each by default)
-  - Rejection feedback via `toast.warning` (`onDropRejected`: too large / too many / unsupported type) — matches project toast guidelines; import wizard keeps an inline `Alert` instead because it is a dedicated step
+  - Rejection feedback via `toast.warning` + shared mapper `getDropzoneRejectionMessage` in `src/lib/utils/dropzone-rejection.ts` (too large / too many / unsupported). Import wizard uses the same helper with an inline `Alert` because it is a dedicated step
   - Visual feedback for selected files with size display
   - File removal before submission
   - Full i18n support (all text comes from translation files)

--- a/llm-instructions/features/transactions/transaction-import-guide.md
+++ b/llm-instructions/features/transactions/transaction-import-guide.md
@@ -56,7 +56,7 @@ src/components/import/
 ├── ColumnMapper.tsx             ← column mapping UI
 └── steps/
     ├── PrepareStep.tsx          ← format info + template download
-    ├── FileUploadStep.tsx       ← react-dropzone + Tauri drag-drop handler
+    ├── FileUploadStep.tsx       ← react-dropzone + Tauri drag-drop; rejection copy via shared `getDropzoneRejectionMessage`
     ├── ColumnMappingStep.tsx
     ├── ImportReviewStep.tsx     ← filter tabs + bulk actions
     └── ImportResultStep.tsx

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "react-countup": "^6.5.3",
         "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.8",
-        "react-dropzone": "^14.3.8",
+        "react-dropzone": "^19.1.1",
         "react-hook-form": "^7.83.0",
         "react-i18next": "^17.0.11",
         "react-resizable-panels": "^3.0.6",
@@ -7607,15 +7607,12 @@
       }
     },
     "node_modules/file-selector": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
-      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-4.1.0.tgz",
+      "integrity": "sha512-Io1mP8CI3zec5Bxy3P3TxdrKnt35Cm8vNIHnZsvyj43l4YFjD4NRInBp240S5bDJQ0EP1jnh7nCAwXsO818OCg==",
       "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
     },
     "node_modules/filelist": {
@@ -8865,6 +8862,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9238,18 +9236,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -9984,23 +9970,6 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10097,20 +10066,25 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
-      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-19.1.1.tgz",
+      "integrity": "sha512-zxuTwbyvP+FSdesiHafT/0UMTX/Ne1ri8XPTn7KM97ZinHKFy3N6KiKEGRiG28ibYV+nG6sHxoJlkVoDxIMHxQ==",
       "license": "MIT",
       "dependencies": {
-        "attr-accept": "^2.2.4",
-        "file-selector": "^2.1.0",
-        "prop-types": "^15.8.1"
+        "attr-accept": "^2.2.5",
+        "file-selector": "^4.0.1"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">= 20"
       },
       "peerDependencies": {
-        "react": ">= 16.8 || 18.0.0"
+        "@types/react": "*",
+        "react": ">= 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-countup": "^6.5.3",
     "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.8",
-    "react-dropzone": "^14.3.8",
+    "react-dropzone": "^19.1.1",
     "react-hook-form": "^7.83.0",
     "react-i18next": "^17.0.11",
     "react-resizable-panels": "^3.0.6",

--- a/public/locales/en/contact.json
+++ b/public/locales/en/contact.json
@@ -54,7 +54,12 @@
       "dropActive": "Drop the files here...",
       "dropInactive": "Drag & drop files here, or click to select",
       "limits": "(Max {{maxFiles}} files, up to {{maxSizeMB}}MB each)",
-      "removeFile": "Remove file"
+      "removeFile": "Remove file",
+      "errors": {
+        "tooLarge": "File is too large (max {{size}}MB)",
+        "tooManyFiles": "You can attach up to {{maxFiles}} files",
+        "unsupportedFormat": "Unsupported file type"
+      }
     }
   }
 }

--- a/public/locales/he/contact.json
+++ b/public/locales/he/contact.json
@@ -54,7 +54,12 @@
       "dropActive": "שחרר את הקבצים כאן...",
       "dropInactive": "גרור ושחרר קבצים כאן, או לחץ לבחירה",
       "limits": "(מקסימום {{maxFiles}} קבצים, עד {{maxSizeMB}}MB כל אחד)",
-      "removeFile": "הסר קובץ"
+      "removeFile": "הסר קובץ",
+      "errors": {
+        "tooLarge": "הקובץ גדול מדי (מקסימום {{size}}MB)",
+        "tooManyFiles": "ניתן לצרף עד {{maxFiles}} קבצים",
+        "unsupportedFormat": "סוג הקובץ אינו נתמך"
+      }
     }
   }
 }

--- a/src/components/import/steps/FileUploadStep.tsx
+++ b/src/components/import/steps/FileUploadStep.tsx
@@ -14,9 +14,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils/index";
+import { getDropzoneRejectionMessage } from "@/lib/utils/dropzone-rejection";
 import { withTimeout } from "@/lib/utils/with-timeout";
 import { parseFile, MAX_FILE_SIZE_BYTES, MAX_ROWS } from "@/lib/import/parsers";
 import type { ParsedFile } from "@/lib/import/import-session.types";
+
+const UPLOAD_REJECTION_KEYS = {
+  tooLarge: "upload.errors.tooLarge",
+  tooManyFiles: "upload.errors.tooManyFiles",
+  unsupportedFormat: "upload.errors.unsupportedFormat",
+} as const;
 
 interface FileUploadStepProps {
   onFileParsed: (file: ParsedFile) => void;
@@ -119,25 +126,12 @@ export function FileUploadStep({ onFileParsed }: FileUploadStepProps) {
 
   const onDropRejected = useCallback(
     (rejections: FileRejection[]) => {
-      const first = rejections[0];
-      const firstError = first?.errors[0];
-      if (!firstError) {
-        setError(t("upload.errors.unsupportedFormat"));
-        return;
-      }
-
-      if (firstError.code === "file-too-large") {
-        const maxMb = Math.round(MAX_FILE_SIZE_BYTES / 1024 / 1024);
-        setError(t("upload.errors.tooLarge", { size: maxMb }));
-        return;
-      }
-
-      if (firstError.code === "too-many-files") {
-        setError(t("upload.errors.tooManyFiles"));
-        return;
-      }
-
-      setError(t("upload.errors.unsupportedFormat"));
+      setError(
+        getDropzoneRejectionMessage(rejections, t, UPLOAD_REJECTION_KEYS, {
+          maxSizeBytes: MAX_FILE_SIZE_BYTES,
+          maxFiles: 1,
+        })
+      );
     },
     [t]
   );

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -35,12 +35,33 @@ export const FileUpload = ({
 }: FileUploadProps) => {
   const { t } = useTranslation("contact");
 
+  // dropzone's `maxFiles` only counts the *current* selection, not files already
+  // in `value`. Pass remaining slots so adding past the cap hits onDropRejected
+  // instead of being silently truncated by `.slice()`.
+  const remainingSlots = Math.max(0, maxFiles - value.length);
+
+  const warnTooManyFiles = useCallback(() => {
+    toast.warning(
+      t(ATTACHMENT_REJECTION_KEYS.tooManyFiles, { maxFiles })
+    );
+  }, [t, maxFiles]);
+
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
-      const newFiles = [...value, ...acceptedFiles].slice(0, maxFiles);
-      onChange(newFiles);
+      if (acceptedFiles.length === 0) return;
+
+      if (remainingSlots <= 0) {
+        warnTooManyFiles();
+        return;
+      }
+
+      if (acceptedFiles.length > remainingSlots) {
+        warnTooManyFiles();
+      }
+
+      onChange([...value, ...acceptedFiles].slice(0, maxFiles));
     },
-    [value, maxFiles, onChange]
+    [value, maxFiles, onChange, remainingSlots, warnTooManyFiles]
   );
 
   const onDropRejected = useCallback(
@@ -63,9 +84,15 @@ export const FileUpload = ({
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
     onDropRejected,
-    maxFiles,
+    // When already at the cap, keep maxFiles >= 1 and reject via validator —
+    // react-dropzone treats maxFiles: 0 as "unlimited".
+    maxFiles: remainingSlots > 0 ? remainingSlots : 1,
     maxSize,
     accept,
+    validator: () =>
+      remainingSlots <= 0
+        ? { code: "too-many-files", message: "Too many files" }
+        : null,
   });
 
   return (

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from "react";
-import { useDropzone } from "react-dropzone";
+import { useDropzone, type FileRejection } from "react-dropzone";
 import { Upload, X, File as FileIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
 
@@ -35,6 +36,35 @@ export const FileUpload = ({
     [value, maxFiles, onChange]
   );
 
+  const onDropRejected = useCallback(
+    (rejections: FileRejection[]) => {
+      const firstError = rejections[0]?.errors[0];
+      if (!firstError) {
+        toast.warning(t("forms.attachments.errors.unsupportedFormat"));
+        return;
+      }
+
+      if (firstError.code === "file-too-large") {
+        toast.warning(
+          t("forms.attachments.errors.tooLarge", {
+            size: Math.round(maxSize / 1024 / 1024),
+          })
+        );
+        return;
+      }
+
+      if (firstError.code === "too-many-files") {
+        toast.warning(
+          t("forms.attachments.errors.tooManyFiles", { maxFiles })
+        );
+        return;
+      }
+
+      toast.warning(t("forms.attachments.errors.unsupportedFormat"));
+    },
+    [t, maxSize, maxFiles]
+  );
+
   const removeFile = (fileToRemove: File) => {
     const newFiles = value.filter((file) => file !== fileToRemove);
     onChange(newFiles);
@@ -42,6 +72,7 @@ export const FileUpload = ({
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
+    onDropRejected,
     maxFiles,
     maxSize,
     accept,

--- a/src/components/ui/file-upload.tsx
+++ b/src/components/ui/file-upload.tsx
@@ -4,7 +4,14 @@ import { Upload, X, File as FileIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { getDropzoneRejectionMessage } from "@/lib/utils/dropzone-rejection";
 import { Button } from "./button";
+
+const ATTACHMENT_REJECTION_KEYS = {
+  tooLarge: "forms.attachments.errors.tooLarge",
+  tooManyFiles: "forms.attachments.errors.tooManyFiles",
+  unsupportedFormat: "forms.attachments.errors.unsupportedFormat",
+} as const;
 
 interface FileUploadProps {
   value: File[];
@@ -38,29 +45,12 @@ export const FileUpload = ({
 
   const onDropRejected = useCallback(
     (rejections: FileRejection[]) => {
-      const firstError = rejections[0]?.errors[0];
-      if (!firstError) {
-        toast.warning(t("forms.attachments.errors.unsupportedFormat"));
-        return;
-      }
-
-      if (firstError.code === "file-too-large") {
-        toast.warning(
-          t("forms.attachments.errors.tooLarge", {
-            size: Math.round(maxSize / 1024 / 1024),
-          })
-        );
-        return;
-      }
-
-      if (firstError.code === "too-many-files") {
-        toast.warning(
-          t("forms.attachments.errors.tooManyFiles", { maxFiles })
-        );
-        return;
-      }
-
-      toast.warning(t("forms.attachments.errors.unsupportedFormat"));
+      toast.warning(
+        getDropzoneRejectionMessage(rejections, t, ATTACHMENT_REJECTION_KEYS, {
+          maxSizeBytes: maxSize,
+          maxFiles,
+        })
+      );
     },
     [t, maxSize, maxFiles]
   );

--- a/src/lib/utils/dropzone-rejection.test.ts
+++ b/src/lib/utils/dropzone-rejection.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import type { FileRejection } from "react-dropzone";
+import {
+  getDropzoneRejectionMessage,
+  getPrimaryDropzoneRejectionCode,
+} from "./dropzone-rejection";
+
+function rejection(code: string, message = "x"): FileRejection[] {
+  return [
+    {
+      file: new File([""], "f.bin"),
+      errors: [{ code, message }],
+    },
+  ];
+}
+
+const keys = {
+  tooLarge: "errors.tooLarge",
+  tooManyFiles: "errors.tooManyFiles",
+  unsupportedFormat: "errors.unsupportedFormat",
+};
+
+describe("getPrimaryDropzoneRejectionCode", () => {
+  it("maps known dropzone codes", () => {
+    expect(getPrimaryDropzoneRejectionCode(rejection("file-too-large"))).toBe(
+      "file-too-large"
+    );
+    expect(getPrimaryDropzoneRejectionCode(rejection("too-many-files"))).toBe(
+      "too-many-files"
+    );
+    expect(
+      getPrimaryDropzoneRejectionCode(rejection("file-invalid-type"))
+    ).toBe("file-invalid-type");
+  });
+
+  it("falls back to unknown for empty or unfamiliar codes", () => {
+    expect(getPrimaryDropzoneRejectionCode([])).toBe("unknown");
+    expect(getPrimaryDropzoneRejectionCode(rejection("custom-code"))).toBe(
+      "unknown"
+    );
+  });
+});
+
+describe("getDropzoneRejectionMessage", () => {
+  it("interpolates size for file-too-large", () => {
+    const t = vi.fn((key: string, opts?: Record<string, string | number>) =>
+      key === keys.tooLarge ? `too-large:${opts?.size}` : key
+    );
+    expect(
+      getDropzoneRejectionMessage(rejection("file-too-large"), t, keys, {
+        maxSizeBytes: 5 * 1024 * 1024,
+      })
+    ).toBe("too-large:5");
+  });
+
+  it("passes maxFiles for too-many-files", () => {
+    const t = vi.fn((key: string, opts?: Record<string, string | number>) =>
+      key === keys.tooManyFiles ? `too-many:${opts?.maxFiles}` : key
+    );
+    expect(
+      getDropzoneRejectionMessage(rejection("too-many-files"), t, keys, {
+        maxSizeBytes: 1024,
+        maxFiles: 3,
+      })
+    ).toBe("too-many:3");
+  });
+
+  it("uses unsupportedFormat for invalid type and unknown codes", () => {
+    const t = vi.fn((key: string) => key);
+    expect(
+      getDropzoneRejectionMessage(rejection("file-invalid-type"), t, keys, {
+        maxSizeBytes: 1024,
+      })
+    ).toBe(keys.unsupportedFormat);
+    expect(
+      getDropzoneRejectionMessage([], t, keys, { maxSizeBytes: 1024 })
+    ).toBe(keys.unsupportedFormat);
+  });
+});

--- a/src/lib/utils/dropzone-rejection.ts
+++ b/src/lib/utils/dropzone-rejection.ts
@@ -1,0 +1,73 @@
+import type { FileRejection } from "react-dropzone";
+
+/**
+ * Known react-dropzone rejection codes we map to user-facing copy.
+ * Anything else falls through to the unsupported/generic message.
+ */
+export type DropzoneRejectionCode =
+  | "file-too-large"
+  | "too-many-files"
+  | "file-invalid-type"
+  | "unknown";
+
+export type DropzoneRejectionMessageKeys = {
+  tooLarge: string;
+  tooManyFiles: string;
+  unsupportedFormat: string;
+};
+
+type Translate = (
+  key: string,
+  options?: Record<string, string | number>
+) => string;
+
+/**
+ * Returns the primary rejection code from a dropzone `onDropRejected` payload.
+ */
+export function getPrimaryDropzoneRejectionCode(
+  rejections: FileRejection[]
+): DropzoneRejectionCode {
+  const code = rejections[0]?.errors[0]?.code;
+  switch (code) {
+    case "file-too-large":
+    case "too-many-files":
+    case "file-invalid-type":
+      return code;
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Maps dropzone rejection codes to a localized user message.
+ * Callers supply i18n keys so contact/import (different namespaces) can share
+ * the same mapping without sharing translation strings.
+ */
+export function getDropzoneRejectionMessage(
+  rejections: FileRejection[],
+  t: Translate,
+  keys: DropzoneRejectionMessageKeys,
+  options: {
+    maxSizeBytes: number;
+    maxFiles?: number;
+  }
+): string {
+  const code = getPrimaryDropzoneRejectionCode(rejections);
+  switch (code) {
+    case "file-too-large":
+      return t(keys.tooLarge, {
+        size: Math.round(options.maxSizeBytes / 1024 / 1024),
+      });
+    case "too-many-files":
+      return t(keys.tooManyFiles, {
+        maxFiles: options.maxFiles ?? 1,
+      });
+    case "file-invalid-type":
+    case "unknown":
+      return t(keys.unsupportedFormat);
+    default: {
+      const _exhaustive: never = code;
+      return _exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Combines Dependabot #362 with proper shared rejection feedback for uploads.

| Change | What |
|---|---|
| #362 | `react-dropzone` 14 → 19.1.1 |
| Shared helper | `getDropzoneRejectionMessage` in `src/lib/utils/dropzone-rejection.ts` |
| Contact | `FileUpload` → `toast.warning` via the helper |
| Import | `FileUploadStep` → inline `Alert` via the same helper |

## Why

Contact previously swallowed dropzone rejections. Import already mapped codes with local `if`s. Both now share one exhaustive code→message mapper; each surface keeps its own feedback channel (toast vs Alert).

## Verification

- `tsc --noEmit` ✅
- `dropzone-rejection.test.ts` ✅

## Docs

- `contact-us-feature.md`
- `transaction-import-guide.md`

## After merge

Close as superseded: #362
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69ed7544-3feb-497d-ae86-05b9efb5cd37?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69ed7544-3feb-497d-ae86-05b9efb5cd37&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

