### PR TITLE
fix(security): clear high npm audit findings and improve CI logs

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -33,21 +33,35 @@ jobs:
           # --omit=dev excludes devDependencies (e.g. esbuild, vite) which are never
           # deployed to production and whose CVEs are dev-server-only concerns.
           AUDIT_RESULT=$(npm audit --omit=dev --json 2>/dev/null || true)
-          
+
           HIGH_COUNT=$(echo "$AUDIT_RESULT" | jq '.metadata.vulnerabilities.high // 0')
           CRITICAL_COUNT=$(echo "$AUDIT_RESULT" | jq '.metadata.vulnerabilities.critical // 0')
-          
+
           echo "High severity: $HIGH_COUNT"
           echo "Critical severity: $CRITICAL_COUNT"
-          
-          if [ "$CRITICAL_COUNT" -gt 0 ]; then
-            echo "❌ Critical vulnerabilities found!"
+
+          if [ "$CRITICAL_COUNT" -gt 0 ] || [ "$HIGH_COUNT" -gt 0 ]; then
+            echo ""
+            echo "Blocking advisories (high/critical):"
+            # Print package + advisory title/url/range so the CI log is actionable
+            # without needing a local npm audit reproduction.
+            echo "$AUDIT_RESULT" | jq -r '
+              .vulnerabilities
+              | to_entries[]
+              | select(.value.severity == "high" or .value.severity == "critical")
+              | . as $pkg
+              | ($pkg.value.via // [])
+              | .[]
+              | select(type == "object")
+              | "- [\($pkg.value.severity | ascii_upcase)] \($pkg.key): \(.title // "unknown")\n  range: \(.range // $pkg.value.range // "n/a")\n  url: \(.url // "n/a")"
+            '
+            echo ""
+            if [ "$CRITICAL_COUNT" -gt 0 ]; then
+              echo "❌ Critical vulnerabilities found!"
+            else
+              echo "⚠️ High severity vulnerabilities found!"
+            fi
             exit 1
           fi
-          
-          if [ "$HIGH_COUNT" -gt 0 ]; then
-            echo "⚠️ High severity vulnerabilities found!"
-            exit 1
-          fi
-          
+
           echo "✅ No high or critical vulnerabilities found"

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.8.0",
-        "postcss": "^8.5.25",
+        "postcss": "^8.5.26",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.65.0",
@@ -6113,9 +6113,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6889,9 +6889,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9741,9 +9741,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9760,7 +9760,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -9897,9 +9897,9 @@
       "license": "MIT"
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.8.0",
-    "postcss": "^8.5.25",
+    "postcss": "^8.5.26",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.65.0",
@@ -119,6 +119,8 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
+    "brace-expansion": "^5.0.9",
+    "dompurify": "^3.4.13",
     "lodash": "^4.17.24",
     "minimatch": "^10.2.3",
     "serialize-javascript": "^7.0.4",


### PR DESCRIPTION
## Summary
- Clear the two high-severity production audit blockers (`brace-expansion` → 5.0.9 via override, nested `nanoid` via `postcss` → 8.5.26) and pin `dompurify` → 3.4.13
- Improve `security-audit.yml` so failures print package + advisory title/range/URL instead of only `High severity: N`
- Unblocks Dependabot PRs that currently inherit the red Security Audit check from `main`

## Test plan
- [x] `npm audit --omit=dev` → `found 0 vulnerabilities`
- [ ] CI `NPM Security Audit` passes on this PR
- [ ] After merge, re-run/rebase Dependabot PRs (#379, #380, #381) and confirm AUDIT goes green
